### PR TITLE
Allow for adding/removing root fields in the document editor

### DIFF
--- a/src/components/Firestore/DocumentEditor/index.test.tsx
+++ b/src/components/Firestore/DocumentEditor/index.test.tsx
@@ -20,22 +20,49 @@ import React from 'react';
 import { FieldType } from '../models';
 import DocumentEditor from './index';
 
-it('renders an editable field', () => {
-  const onChange = jest.fn();
-  const { getByLabelText, getByPlaceholderText, getByDisplayValue } = render(
-    <DocumentEditor value={{ hello: 'world' }} onChange={onChange} />
-  );
-  expect(getByLabelText('Field').value).toBe('hello');
-  // Select does not properly wire up the label aria properly
-  expect(getByDisplayValue('string')).not.toBe(null);
-  expect(getByLabelText('Value').value).toBe('world');
-
-  fireEvent.change(getByLabelText('Value'), {
-    target: { value: 'new' },
+describe('with basic root fields', () => {
+  let onChange;
+  let result;
+  beforeEach(() => {
+    onChange = jest.fn();
+    result = render(
+      <DocumentEditor value={{ hello: 'world' }} onChange={onChange} />
+    );
   });
 
-  expect(getByLabelText('Value').value).toBe('new');
-  expect(onChange).toHaveBeenCalledWith({ hello: 'new' });
+  it('renders current field name, type, value', () => {
+    const { getByLabelText, getByDisplayValue } = result;
+
+    expect(getByLabelText('Field').value).toBe('hello');
+    // Select does not properly wire up the label aria properly
+    expect(getByDisplayValue('string')).not.toBe(null);
+    expect(getByLabelText('Value').value).toBe('world');
+  });
+
+  it('edits the value', () => {
+    const { getByLabelText } = result;
+
+    fireEvent.change(getByLabelText('Value'), {
+      target: { value: 'new' },
+    });
+
+    expect(getByLabelText('Value').value).toBe('new');
+    expect(onChange).toHaveBeenCalledWith({ hello: 'new' });
+  });
+
+  it('adds root-fields', () => {
+    const { getByText } = result;
+
+    getByText('add').click();
+    expect(onChange).toHaveBeenCalledWith({ hello: 'world', '': '' });
+  });
+
+  it('removes root-fields', () => {
+    const { getByText } = result;
+
+    getByText('delete').click();
+    expect(onChange).toHaveBeenCalledWith({});
+  });
 });
 
 it('renders an editable field with children', () => {
@@ -86,9 +113,9 @@ describe('changing types', () => {
   });
 
   it('switches to an array', () => {
-    const { getByText } = result;
+    const { getAllByText } = result;
     setType(FieldType.ARRAY);
-    expect(getByText('add')).not.toBe(null);
+    expect(getAllByText('add').length).toBe(2);
   });
 
   it('switches to a boolean', () => {
@@ -104,9 +131,9 @@ describe('changing types', () => {
   });
 
   it('switches to a map', () => {
-    const { getByText } = result;
+    const { getAllByText } = result;
     setType(FieldType.MAP);
-    expect(getByText('add')).not.toBe(null);
+    expect(getAllByText('add').length).toBe(2);
   });
 
   it('switches to null', () => {

--- a/src/components/Firestore/DocumentEditor/index.tsx
+++ b/src/components/Firestore/DocumentEditor/index.tsx
@@ -65,24 +65,30 @@ export function supportsEditing(value: FirestoreAny): boolean {
   return supportedFieldTypeSet.has(getFieldType(value));
 }
 
-/** Entry point for a Document/Field editor */
+/**
+ * Entry point for a Document/Field editor
+ *
+ * areRootKeysMutable: can a root key be changed, this is generally not the case
+ *     once a field has been persisted via the SDK.
+ * areRootFielsMutable: can a root field be added/removed.
+ */
 const DocumentEditor: React.FC<{
   value: FirestoreMap;
   onChange?: (value: FirestoreMap) => void;
   areRootKeysMutable?: boolean;
-  limitToOneField?: boolean;
+  areRootFieldsMutable?: boolean;
 }> = ({
   value,
   onChange,
   areRootKeysMutable = true,
-  limitToOneField = false,
+  areRootFieldsMutable = true,
 }) => {
   return (
     <DocumentProvider value={value}>
       <RootField
         onChange={onChange}
         areRootKeysMutable={areRootKeysMutable}
-        limitToOneField={limitToOneField}
+        areRootFieldsMutable={areRootFieldsMutable}
       />
     </DocumentProvider>
   );
@@ -95,8 +101,8 @@ const DocumentEditor: React.FC<{
 const RootField: React.FC<{
   onChange?: (value: FirestoreMap) => void;
   areRootKeysMutable: boolean;
-  limitToOneField: boolean;
-}> = ({ onChange, areRootKeysMutable, limitToOneField }) => {
+  areRootFieldsMutable: boolean;
+}> = ({ onChange, areRootKeysMutable, areRootFieldsMutable }) => {
   const state = useDocumentState();
   const dispatch = useDocumentDispatch()!;
 
@@ -109,7 +115,7 @@ const RootField: React.FC<{
       {Object.keys(state).map(field => (
         <React.Fragment key={field}>
           <NestedEditor path={[field]} isKeyMutable={areRootKeysMutable} />
-          {!limitToOneField && (
+          {areRootFieldsMutable && (
             <IconButton
               icon="delete"
               label="Remove field"
@@ -118,7 +124,7 @@ const RootField: React.FC<{
           )}
         </React.Fragment>
       ))}
-      {!limitToOneField && (
+      {areRootFieldsMutable && (
         <IconButton
           icon="add"
           label="Add field"

--- a/src/components/Firestore/DocumentEditor/index.tsx
+++ b/src/components/Firestore/DocumentEditor/index.tsx
@@ -70,10 +70,20 @@ const DocumentEditor: React.FC<{
   value: FirestoreMap;
   onChange?: (value: FirestoreMap) => void;
   areRootKeysMutable?: boolean;
-}> = ({ value, onChange, areRootKeysMutable = true }) => {
+  limitToOneField?: boolean;
+}> = ({
+  value,
+  onChange,
+  areRootKeysMutable = true,
+  limitToOneField = false,
+}) => {
   return (
     <DocumentProvider value={value}>
-      <RootField onChange={onChange} areRootKeysMutable={areRootKeysMutable} />
+      <RootField
+        onChange={onChange}
+        areRootKeysMutable={areRootKeysMutable}
+        limitToOneField={limitToOneField}
+      />
     </DocumentProvider>
   );
 };
@@ -85,8 +95,10 @@ const DocumentEditor: React.FC<{
 const RootField: React.FC<{
   onChange?: (value: FirestoreMap) => void;
   areRootKeysMutable: boolean;
-}> = ({ onChange, areRootKeysMutable }) => {
+  limitToOneField: boolean;
+}> = ({ onChange, areRootKeysMutable, limitToOneField }) => {
   const state = useDocumentState();
+  const dispatch = useDocumentDispatch()!;
 
   useEffect(() => {
     onChange && onChange(state);
@@ -95,12 +107,24 @@ const RootField: React.FC<{
   return (
     <>
       {Object.keys(state).map(field => (
-        <NestedEditor
-          key={field}
-          path={[field]}
-          isKeyMutable={areRootKeysMutable}
-        />
+        <React.Fragment key={field}>
+          <NestedEditor path={[field]} isKeyMutable={areRootKeysMutable} />
+          {!limitToOneField && (
+            <IconButton
+              icon="delete"
+              label="Remove field"
+              onClick={e => dispatch(actions.deleteField([field]))}
+            />
+          )}
+        </React.Fragment>
       ))}
+      {!limitToOneField && (
+        <IconButton
+          icon="add"
+          label="Add field"
+          onClick={e => dispatch(actions.addField({ path: [''], value: '' }))}
+        />
+      )}
     </>
   );
 };

--- a/src/components/Firestore/DocumentEditor/store.tsx
+++ b/src/components/Firestore/DocumentEditor/store.tsx
@@ -26,7 +26,6 @@ import * as actions from './actions';
 
 const reducer = createReducer<FirestoreMap, Action>({})
   .handleAction(actions.reset, (state, { payload }) => {
-    console.log('reset', payload);
     return payload;
   })
   .handleAction(

--- a/src/components/Firestore/DocumentEditor/store.tsx
+++ b/src/components/Firestore/DocumentEditor/store.tsx
@@ -26,6 +26,7 @@ import * as actions from './actions';
 
 const reducer = createReducer<FirestoreMap, Action>({})
   .handleAction(actions.reset, (state, { payload }) => {
+    console.log('reset', payload);
     return payload;
   })
   .handleAction(

--- a/src/components/Firestore/DocumentPreview/InlineEditor.tsx
+++ b/src/components/Firestore/DocumentPreview/InlineEditor.tsx
@@ -52,7 +52,7 @@ const InlineEditor: React.FC<{
             value={value}
             onChange={handleChange}
             areRootKeysMutable={areRootKeysMutable}
-            limitToOneField={true}
+            areRootFieldsMutable={false}
           />
         </div>
         <CardActionButtons>

--- a/src/components/Firestore/DocumentPreview/InlineEditor.tsx
+++ b/src/components/Firestore/DocumentPreview/InlineEditor.tsx
@@ -52,6 +52,7 @@ const InlineEditor: React.FC<{
             value={value}
             onChange={handleChange}
             areRootKeysMutable={areRootKeysMutable}
+            limitToOneField={true}
           />
         </div>
         <CardActionButtons>


### PR DESCRIPTION
Where applicable (in the AddDocument-step) allow for adding/removing root nodes from the document store.

![image](https://user-images.githubusercontent.com/1452216/77103574-ff07f300-69f0-11ea-8d9f-3e3bfa3f2ee8.png)
