### PR TITLE
Allow Firestore panels to stretch vertically

### DIFF
--- a/src/components/Firestore/index.scss
+++ b/src/components/Firestore/index.scss
@@ -15,6 +15,7 @@
  */
 
 @import '../common/color';
+@import '../common/utils';
 @import '../App_variables';
 
 .Firestore {
@@ -42,6 +43,7 @@
   display: flex;
   flex-direction: row !important;
   overflow: hidden;
+  flex: 1 1 auto; // grow panels to bottom of card
 }
 
 // TODO: Remove this wrapper and merge everything in document into a big list.
@@ -98,6 +100,7 @@
     padding: 0;
 
     .mdc-button {
+      @include ellipsis;
       border-radius: 0;
       width: 100%;
     }


### PR DESCRIPTION
<img width="951" alt="Screen Shot 2020-03-23 at 8 41 00 PM" src="https://user-images.githubusercontent.com/702990/77385939-c0529f80-6d46-11ea-8a40-2b9d82212bfa.png">
