### PR TITLE
Revert "Update dependency prettier-plugin-import-sort to v0.0.4"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15356,9 +15356,9 @@
       "dev": true
     },
     "prettier-plugin-import-sort": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-import-sort/-/prettier-plugin-import-sort-0.0.4.tgz",
-      "integrity": "sha512-KyPKnWbFER9NJk+qidbGYSPO82wF1OSNdnZGtVSBG6Te0ZAWOvZ5fDeTaaHczG8UIaePgSNE1H1DoUMAykjsEg==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-import-sort/-/prettier-plugin-import-sort-0.0.3.tgz",
+      "integrity": "sha512-wDMt9bGg59H/+OBpD13lKaOYTtyuqmtzzO8ZH7MhpJadm7SZctl6l+OdXmqbK0bxxLYs5LDRxJageUYynmKOmQ==",
       "dev": true,
       "requires": {
         "import-sort": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "mutationobserver-shim": "^0.3.3",
     "node-sass": "^4.13.1",
     "prettier": "^1.19.1",
-    "prettier-plugin-import-sort": "0.0.4",
+    "prettier-plugin-import-sort": "0.0.3",
     "webpack-cli": "^3.3.11"
   },
   "husky": {


### PR DESCRIPTION
Reverts firebase/firebase-tools-ui#76

The update broke `npm run fmt` and prettier hooks on pre-commit.

```
Error: Cannot find module 'prettier/parser-babel'
```

