### PR TITLE
Fix adding at root

### DIFF
--- a/src/components/Database/DataViewer/NodeLeaf.tsx
+++ b/src/components/Database/DataViewer/NodeLeaf.tsx
@@ -98,7 +98,7 @@ export const NodeLeaf = React.memo<Props>(function NodeLeaf$({
       {isAdding && (
         <InlineEditor
           rtdb
-          value={{ key: value }}
+          value={{ [realtimeRef.push().key!]: '' }}
           onCancel={() => setIsAdding(false)}
           onSave={handleAddSuccess}
           areRootKeysMutable={true}


### PR DESCRIPTION
Before, fixed key, and no value box (because `null` is not a valid type dropdown):

<img width="767" alt="Screen Shot 2020-03-27 at 1 16 45 PM" src="https://user-images.githubusercontent.com/702990/77796831-3ef05b00-702d-11ea-88fa-454d513870c9.png">


After, push ID key with blank string value:

<img width="761" alt="Screen Shot 2020-03-27 at 1 15 21 PM" src="https://user-images.githubusercontent.com/702990/77796863-52032b00-702d-11ea-963b-edddb9da88c6.png">
