### PR TITLE
Fix menus to use auto width

### DIFF
--- a/src/components/Database/DataViewer/NodeActions.tsx
+++ b/src/components/Database/DataViewer/NodeActions.tsx
@@ -68,7 +68,7 @@ export const NodeActions = React.memo<Props>(function NodeActions$({
   onExpandRequested,
   queryParams,
 }) {
-  const [isMenuOpen] = useState(false);
+  const [isMenuOpen, setMenuOpen] = useState(false);
   const [isAdding, setIsAdding] = useState(false);
   const [showQueryUi, setShowQueryUi] = useState(false);
   const [cloneDialogIsOpen, setCloneDialogIsOpen] = useState(false);
@@ -131,7 +131,11 @@ export const NodeActions = React.memo<Props>(function NodeActions$({
           />
         </Tooltip>
       ) : null}
-      <SimpleMenu handle={<IconButton icon="more_vert" />}>
+      <SimpleMenu
+        handle={<IconButton icon="more_vert" />}
+        onOpen={() => setMenuOpen(true)}
+        onClose={() => setMenuOpen(false)}
+      >
         <MenuItem onClick={removeNode}>
           <Icon icon="delete" /> Remove
         </MenuItem>

--- a/src/components/Database/DataViewer/NodeActions.tsx
+++ b/src/components/Database/DataViewer/NodeActions.tsx
@@ -132,6 +132,13 @@ export const NodeActions = React.memo<Props>(function NodeActions$({
         </Tooltip>
       ) : null}
       <SimpleMenu
+        hoistToBody={
+          /*
+           * Actions show on hover, so hoisting has some weird effects, popping
+           * in and out of the top left corner
+           */
+          false
+        }
         handle={<IconButton icon="more_vert" />}
         onOpen={() => setMenuOpen(true)}
         onClose={() => setMenuOpen(false)}

--- a/src/components/Database/DataViewer/NodeActions.tsx
+++ b/src/components/Database/DataViewer/NodeActions.tsx
@@ -16,7 +16,7 @@
 
 import { Icon } from '@rmwc/icon';
 import { IconButton } from '@rmwc/icon-button';
-import { Menu, MenuItem, MenuSurfaceAnchor } from '@rmwc/menu';
+import { MenuItem, SimpleMenu } from '@rmwc/menu';
 import { Tooltip } from '@rmwc/tooltip';
 import * as React from 'react';
 import { useState } from 'react';
@@ -68,7 +68,7 @@ export const NodeActions = React.memo<Props>(function NodeActions$({
   onExpandRequested,
   queryParams,
 }) {
-  const [isMenuOpen, setMenuOpen] = useState(false);
+  const [isMenuOpen] = useState(false);
   const [isAdding, setIsAdding] = useState(false);
   const [showQueryUi, setShowQueryUi] = useState(false);
   const [cloneDialogIsOpen, setCloneDialogIsOpen] = useState(false);
@@ -131,24 +131,22 @@ export const NodeActions = React.memo<Props>(function NodeActions$({
           />
         </Tooltip>
       ) : null}
-      <MenuSurfaceAnchor>
-        <Menu open={isMenuOpen} onClose={() => setMenuOpen(false)}>
-          <MenuItem onClick={removeNode}>
-            <Icon icon="delete" /> Remove
+      <SimpleMenu handle={<IconButton icon="more_vert" />}>
+        <MenuItem onClick={removeNode}>
+          <Icon icon="delete" /> Remove
+        </MenuItem>
+        {!isRoot && (
+          <MenuItem onClick={() => setCloneDialogIsOpen(true)}>
+            <Icon icon="file_copy" /> Clone
           </MenuItem>
-          {!isRoot && (
-            <MenuItem onClick={() => setCloneDialogIsOpen(true)}>
-              <Icon icon="file_copy" /> Clone
-            </MenuItem>
-          )}
-          {!isRoot && (
-            <MenuItem onClick={() => setRenameDialogIsOpen(true)}>
-              <Icon icon="edit" /> Rename
-            </MenuItem>
-          )}
-        </Menu>
-        <IconButton icon="more_vert" onClick={() => setMenuOpen(!isMenuOpen)} />
-      </MenuSurfaceAnchor>
+        )}
+        {!isRoot && (
+          <MenuItem onClick={() => setRenameDialogIsOpen(true)}>
+            <Icon icon="edit" /> Rename
+          </MenuItem>
+        )}
+      </SimpleMenu>
+
       {/* Extra UI that shows when actions are triggered */}
       <div className="NodeActions__additional-ui">
         {isAdding && (

--- a/src/components/Database/Database.tsx
+++ b/src/components/Database/Database.tsx
@@ -71,7 +71,7 @@ export const Database: React.FC<Props> = ({ config, namespace, path }) => {
             inputPrefix={getPrefix(ref)}
             onNavigate={handleNavigate}
           >
-            <SimpleMenu handle={<IconButton icon="more_vert" />}>
+            <SimpleMenu handle={<IconButton icon="more_vert" />} hoistToBody>
               <MenuItem disabled>Export JSON</MenuItem>
               <MenuItem disabled>Import JSON</MenuItem>
               <ListDivider />

--- a/src/components/Firestore/Document.tsx
+++ b/src/components/Firestore/Document.tsx
@@ -93,7 +93,7 @@ export const Document: React.FC<{ reference: firestore.DocumentReference }> = ({
         id={reference.id}
         icon={<Icon icon={{ icon: 'insert_drive_file', size: 'small' }} />}
       >
-        <SimpleMenu handle={<IconButton icon="more_vert" />}>
+        <SimpleMenu handle={<IconButton icon="more_vert" />} hoistToBody>
           <MenuItem onClick={handleDeleteDocument}>Delete document</MenuItem>
           <MenuItem onClick={handleDeleteFields}>Delete all fields</MenuItem>
         </SimpleMenu>


### PR DESCRIPTION
Any menu inside a flex will likely need `hoistToBody`

<img width="392" alt="Screen Shot 2020-03-27 at 1 39 44 PM" src="https://user-images.githubusercontent.com/702990/77798821-d7d4a580-7030-11ea-9019-e9f63dc6c694.png">
<img width="415" alt="Screen Shot 2020-03-27 at 1 39 50 PM" src="https://user-images.githubusercontent.com/702990/77798825-d905d280-7030-11ea-84e4-5cfe41c549d6.png">
