### PR TITLE
Even more compact header

### DIFF
--- a/src/components/App/AppBar.scss
+++ b/src/components/App/AppBar.scss
@@ -23,7 +23,7 @@
   .AppBar-title-row {
     align-items: center;
     display: flex;
-    height: 48px;
+    margin-top: 8px;
   }
 
   .AppBar-title {
@@ -48,7 +48,7 @@
 
   .mdc-tab {
     &:not(:first-of-type) {
-      margin-left: 16px;
+      margin-left: 24px;
     }
     &:not(.mdc-tab--active) .mdc-tab__text-label {
       color: var(--mdc-theme-on-surface);

--- a/src/components/common/_material-overrides.scss
+++ b/src/components/common/_material-overrides.scss
@@ -42,7 +42,7 @@
   }
 }
 
-$mdc-tab-height: 44px;
+$mdc-tab-height: 40px;
 @import '@material/tab-bar/mdc-tab-bar';
 @import '@material/tab/mdc-tab';
 @import '@material/tab-scroller/mdc-tab-scroller';


### PR DESCRIPTION
Tweaked with Nate V

- smaller tab height
- less vertical space on title

<img width="798" alt="Screen Shot 2020-03-30 at 2 58 27 PM" src="https://user-images.githubusercontent.com/702990/77965912-eae8af00-7296-11ea-8589-a9dcf0d0bb07.png">
