### PR TITLE
Use Result in selectors wherever possible.

### DIFF
--- a/src/components/Database/index.test.tsx
+++ b/src/components/Database/index.test.tsx
@@ -33,8 +33,8 @@ describe('DatabaseRoute', () => {
   it('renders loading when projectId is not ready', () => {
     const { getByText } = render(
       <DatabaseRoute
-        projectIdRemote={{ loading: true }}
-        configRemote={{ loading: false, result: { data: sampleConfig } }}
+        projectIdResult={undefined}
+        configResult={{ data: sampleConfig }}
       />
     );
     expect(getByText('Loading...')).not.toBeNull();
@@ -42,8 +42,8 @@ describe('DatabaseRoute', () => {
   it('renders loading when config is not ready', () => {
     const { getByText } = render(
       <DatabaseRoute
-        projectIdRemote={{ loading: false, result: { data: 'foo' } }}
-        configRemote={{ loading: true }}
+        projectIdResult={{ data: 'foo' }}
+        configResult={undefined}
       />
     );
     expect(getByText('Loading...')).not.toBeNull();
@@ -51,11 +51,8 @@ describe('DatabaseRoute', () => {
   it('renders error when loading config fails', () => {
     const { getByText } = render(
       <DatabaseRoute
-        projectIdRemote={{ loading: false, result: { data: 'foo' } }}
-        configRemote={{
-          loading: false,
-          result: { error: { message: 'Oh, snap!' } },
-        }}
+        projectIdResult={{ data: 'foo' }}
+        configResult={{ error: { message: 'Oh, snap!' } }}
       />
     );
     expect(getByText(/currently off/)).not.toBeNull();
@@ -63,11 +60,8 @@ describe('DatabaseRoute', () => {
   it('renders "emulator is off" when config is not present', () => {
     const { getByText } = render(
       <DatabaseRoute
-        projectIdRemote={{ loading: false, result: { data: 'foo' } }}
-        configRemote={{
-          loading: false,
-          result: { data: undefined /* emulator absent */ },
-        }}
+        projectIdResult={{ data: 'foo' }}
+        configResult={{ data: undefined /* emulator absent */ }}
       />
     );
     expect(getByText(/currently off/)).not.toBeNull();

--- a/src/components/Database/index.tsx
+++ b/src/components/Database/index.tsx
@@ -26,23 +26,26 @@ import {
 
 import { createStructuredSelector } from '../../store';
 import { DatabaseConfig } from '../../store/config';
-import { getDatabaseConfig, getProjectId } from '../../store/config/selectors';
-import { combineData, squash } from '../../store/utils';
+import {
+  getDatabaseConfigResult,
+  getProjectIdResult,
+} from '../../store/config/selectors';
+import { combineData, handle } from '../../store/utils';
 import Database from './Database';
 import DatabaseContainer from './DatabaseContainer';
 
 export const mapStateToProps = createStructuredSelector({
-  projectIdRemote: getProjectId,
-  configRemote: getDatabaseConfig,
+  projectIdResult: getProjectIdResult,
+  configResult: getDatabaseConfigResult,
 });
 
 export type PropsFromState = ReturnType<typeof mapStateToProps>;
 
 export const DatabaseRoute: React.FC<PropsFromState> = ({
-  projectIdRemote,
-  configRemote,
+  projectIdResult,
+  configResult,
 }) => {
-  return squash(combineData(projectIdRemote, configRemote), {
+  return handle(combineData(projectIdResult, configResult), {
     onNone: () => <DatabaseRouteLoading />,
     onError: () => <DatabaseRouteDisabled />,
     onData: ([projectId, config]) =>

--- a/src/components/Firestore/index.test.tsx
+++ b/src/components/Firestore/index.test.tsx
@@ -37,8 +37,8 @@ describe('FirestoreRoute', () => {
   it('renders loading when projectId is not ready', () => {
     const { getByText } = render(
       <FirestoreRoute
-        projectIdRemote={{ loading: true }}
-        configRemote={{ loading: false, result: { data: sampleConfig } }}
+        projectIdResult={undefined}
+        configResult={{ data: sampleConfig }}
       />
     );
     expect(getByText('Loading...')).not.toBeNull();
@@ -46,8 +46,8 @@ describe('FirestoreRoute', () => {
   it('renders loading when config is not ready', () => {
     const { getByText } = render(
       <FirestoreRoute
-        projectIdRemote={{ loading: false, result: { data: 'foo' } }}
-        configRemote={{ loading: true }}
+        projectIdResult={{ data: 'foo' }}
+        configResult={undefined}
       />
     );
     expect(getByText('Loading...')).not.toBeNull();
@@ -55,11 +55,8 @@ describe('FirestoreRoute', () => {
   it('renders error when loading config fails', () => {
     const { getByText } = render(
       <FirestoreRoute
-        projectIdRemote={{ loading: false, result: { data: 'foo' } }}
-        configRemote={{
-          loading: false,
-          result: { error: { message: 'Oh, snap!' } },
-        }}
+        projectIdResult={{ data: 'foo' }}
+        configResult={{ error: { message: 'Oh, snap!' } }}
       />
     );
     expect(getByText(/currently off/)).not.toBeNull();
@@ -67,11 +64,8 @@ describe('FirestoreRoute', () => {
   it('renders "emulator is off" when config is not present', () => {
     const { getByText } = render(
       <FirestoreRoute
-        projectIdRemote={{ loading: false, result: { data: 'foo' } }}
-        configRemote={{
-          loading: false,
-          result: { data: undefined /* emulator absent */ },
-        }}
+        projectIdResult={{ data: 'foo' }}
+        configResult={{ data: undefined /* emulator absent */ }}
       />
     );
     expect(getByText(/currently off/)).not.toBeNull();

--- a/src/components/Firestore/index.tsx
+++ b/src/components/Firestore/index.tsx
@@ -26,8 +26,11 @@ import { useHistory, useLocation } from 'react-router-dom';
 
 import { createStructuredSelector } from '../../store';
 import { FirestoreConfig } from '../../store/config';
-import { getFirestoreConfig, getProjectId } from '../../store/config/selectors';
-import { combineData, squash } from '../../store/utils';
+import {
+  getFirestoreConfigResult,
+  getProjectIdResult,
+} from '../../store/config/selectors';
+import { combineData, handle } from '../../store/utils';
 import { CustomThemeProvider } from '../../themes';
 import { InteractiveBreadCrumbBar } from '../common/InteractiveBreadCrumbBar';
 import DatabaseApi from './api';
@@ -36,17 +39,17 @@ import { promptClearAll } from './dialogs/clearAll';
 import { Root } from './Document';
 
 export const mapStateToProps = createStructuredSelector({
-  projectIdRemote: getProjectId,
-  configRemote: getFirestoreConfig,
+  projectIdResult: getProjectIdResult,
+  configResult: getFirestoreConfigResult,
 });
 
 export type PropsFromState = ReturnType<typeof mapStateToProps>;
 
 export const FirestoreRoute: React.FC<PropsFromState> = ({
-  projectIdRemote,
-  configRemote,
+  projectIdResult,
+  configResult,
 }) => {
-  return squash(combineData(projectIdRemote, configRemote), {
+  return handle(combineData(projectIdResult, configResult), {
     onNone: () => <FirestoreRouteLoading />,
     onError: () => <FirestoreRouteDisabled />,
     onData: ([projectId, config]) =>

--- a/src/store/config/selectors.ts
+++ b/src/store/config/selectors.ts
@@ -1,18 +1,27 @@
 import { createSelector } from 'reselect';
 
-import { mapResult } from '../utils';
+import { map } from '../utils';
 import { AppState } from '..';
 
+// Get the RemoteResult wrapper for config. If you only care about result,
+// use getConfigResult instead for better caching.
 export const getConfig = (state: AppState) => state.config;
 
-export const getProjectId = createSelector(getConfig, result =>
-  mapResult(result, config => config.projectId)
+export const getConfigResult = (state: AppState) => state.config.result;
+
+// Get whether config is being loaded / refreshed. Note: To check whether config
+// is present, use getConfigResult. This only tells whether we're fetching.
+export const getConfigLoading = (state: AppState) => state.config.loading;
+
+export const getProjectIdResult = createSelector(getConfigResult, result =>
+  map(result, config => config.projectId)
 );
 
-export const getDatabaseConfig = createSelector(getConfig, result =>
-  mapResult(result, config => config.database)
+export const getDatabaseConfigResult = createSelector(getConfigResult, result =>
+  map(result, config => config.database)
 );
 
-export const getFirestoreConfig = createSelector(getConfig, result =>
-  mapResult(result, config => config.firestore)
+export const getFirestoreConfigResult = createSelector(
+  getConfigResult,
+  result => map(result, config => config.firestore)
 );

--- a/src/store/database/sagas.ts
+++ b/src/store/database/sagas.ts
@@ -27,7 +27,10 @@ import { createSelector } from 'reselect';
 import { ActionType, getType } from 'typesafe-actions';
 
 import { DatabaseConfig } from '../config';
-import { getDatabaseConfig, getProjectId } from '../config/selectors';
+import {
+  getDatabaseConfigResult,
+  getProjectIdResult,
+} from '../config/selectors';
 import { combineData, hasError } from '../utils';
 import {
   databasesFetchError,
@@ -54,26 +57,26 @@ export interface GetDbConfigReturn {
 }
 
 const getProjectIdAndDbConfig = createSelector(
-  getProjectId,
-  getDatabaseConfig,
+  getProjectIdResult,
+  getDatabaseConfigResult,
   combineData
 );
 
-type ProjectIdAndDbConfigRemote = ReturnType<typeof getProjectIdAndDbConfig>;
+type ProjectIdAndDbConfigResult = ReturnType<typeof getProjectIdAndDbConfig>;
 
 export function* getDbConfig(): Generator<unknown, GetDbConfigReturn> {
-  const remote = (yield select(
+  const result = (yield select(
     getProjectIdAndDbConfig
-  )) as ProjectIdAndDbConfigRemote;
-  if (!remote.result) {
+  )) as ProjectIdAndDbConfigResult;
+  if (!result) {
     throw new Error('Database emulator config is not ready yet.');
   }
-  if (hasError(remote.result)) {
+  if (hasError(result)) {
     throw new Error(
-      'Error fetching Database emulator config: ' + remote.result.error.message
+      'Error fetching Database emulator config: ' + result.error.message
     );
   }
-  const [projectId, config] = remote.result.data;
+  const [projectId, config] = result.data;
   if (!config) {
     throw new Error('Database emulator is not started!');
   }

--- a/src/store/utils.ts
+++ b/src/store/utils.ts
@@ -5,29 +5,34 @@ export interface ErrorInfo {
   message: string;
 }
 
-// Represents a piece of remote info, which may be
-// - No info and not loading (initial)
-// - No info and loading (fetching)
-// - Has info and not loading (completed)
-// - Has info and loading (refreshing)
-export type Remote<T> = { result?: T; loading: boolean };
-
 /* Represents result of a task, either success (with data) or error. */
 export type Result<T, E = ErrorInfo> = DataResult<T> | ErrorResult<E>;
 export type DataResult<T> = { data: T };
 export type ErrorResult<E> = { error: E };
 
-export type RemoteResult<T, E = ErrorInfo> = Remote<Result<T, E>>;
+// Type helper to extract the type of T.data.
+export type DataTypeOf<T extends Result<any, any>> = T extends Result<
+  infer D,
+  any
+>
+  ? D
+  : any;
 
-// Type helper to extract the type of T.result.data.
-export type DataTypeOf<
-  T extends RemoteResult<any, any>
-> = T extends RemoteResult<infer D, any> ? D : any;
+export type DataTypeIfPresent<
+  T extends Result<any, any> | undefined
+> = T extends DataResult<infer D> ? D : never;
 
-// Type helper to extract the type of T.result.error.
-export type ErrorTypeOf<
-  T extends RemoteResult<any, any>
-> = T extends RemoteResult<any, infer E> ? E : any;
+// Type helper to extract the type of T.error.
+export type ErrorTypeOf<T extends Result<any, any>> = T extends Result<
+  any,
+  infer E
+>
+  ? E
+  : any;
+
+export type ErrorTypeIfPresent<
+  T extends Result<any, any> | undefined
+> = T extends ErrorResult<infer E> ? E : never;
 
 export function hasData<T, E>(
   result: Result<T, E> | undefined
@@ -44,9 +49,31 @@ export function hasError<T, E>(
 export function map<T, E, R>(
   result: Result<T, E>,
   dataMapper: (data: T) => R
-): Result<R, E> {
+): Result<R, E>;
+
+// Transform data if present or return error / undefined unchanged.
+export function map<T, E, R>(
+  result: Result<T, E> | undefined,
+  dataMapper: (data: T) => R
+): Result<R, E> | undefined;
+
+// (Implementation of overloaded function. Not exposed.)
+export function map<T, E, R>(
+  result: Result<T, E> | undefined,
+  dataMapper: (data: T) => R
+): Result<R, E> | undefined {
+  if (result === undefined) return undefined;
   return 'error' in result ? result : { data: dataMapper(result.data) };
 }
+
+// Represents a piece of remote info, which may be
+// - No info and not loading (initial)
+// - No info and loading (fetching)
+// - Has info and not loading (completed)
+// - Has info and loading (refreshing)
+export type Remote<T> = { result?: T; loading: boolean };
+
+export type RemoteResult<T, E = ErrorInfo> = Remote<Result<T, E>>;
 
 // Transform result.data if present or return result.error unchanged.
 export function mapResult<T, E, R>(
@@ -55,45 +82,64 @@ export function mapResult<T, E, R>(
 ): RemoteResult<R, E> {
   return {
     loading: remoteResult.loading,
-    result:
-      remoteResult.result === undefined
-        ? undefined
-        : map(remoteResult.result, dataMapper),
+    result: map(remoteResult.result, dataMapper),
   };
 }
 
-export type DataTypeOfEach<T extends ReadonlyArray<RemoteResult<any, any>>> = {
-  [P in keyof T]: T[P] extends RemoteResult<any, any> ? DataTypeOf<T[P]> : T[P];
+export type DataTypeOfEach<
+  T extends ReadonlyArray<Result<any, any> | undefined>
+> = {
+  [P in keyof T]: T[P] extends Result<any, any> | undefined
+    ? DataTypeIfPresent<T[P]>
+    : T[P];
 };
 
 /**
- * Combine result.data of the remote results, or return first error encountered.
+ * Combine data of the remote results, or return first error encountered.
  *
- * If there are no errors but any result is undefined, return undefined result.
+ * If there are no errors but any result is undefined, return undefined.
  */
-export function combineData<Arr extends ReadonlyArray<RemoteResult<any, any>>>(
-  ...remoteResults: Arr
-): RemoteResult<DataTypeOfEach<Arr>, ErrorTypeOf<Arr[number]>> {
-  const loading = remoteResults.some(rr => rr.loading);
-  for (const remoteResult of remoteResults) {
-    if (hasError(remoteResult.result)) {
-      return { loading, result: remoteResult.result };
+export function combineData<
+  Arr extends ReadonlyArray<Result<any, any> | undefined>
+>(
+  ...results: Arr
+): Result<DataTypeOfEach<Arr>, ErrorTypeIfPresent<Arr[number]>> | undefined {
+  for (const result of results) {
+    if (hasError(result)) {
+      return result;
     }
   }
-  for (const remoteResult of remoteResults) {
-    if (remoteResult.result === undefined) {
-      return { loading, result: undefined };
+  for (const result of results) {
+    if (result === undefined) {
+      return undefined;
     }
   }
 
   return {
-    loading,
-    result: {
-      data: (remoteResults.map(
-        rr => (rr.result as DataResult<unknown>).data
-      ) as unknown) as DataTypeOfEach<Arr>,
-    },
+    data: (results.map(
+      result => (result as DataResult<unknown>).data
+    ) as unknown) as DataTypeOfEach<Arr>,
   };
+}
+
+// Handle missing / data / error cases of a result and return a single value.
+export function handle<T, E, R>(
+  result: Result<T, E> | undefined,
+  mappers: {
+    onNone: () => R;
+    onData: (data: T) => R;
+    onError: (error: E) => R;
+  }
+): R {
+  if (result === undefined) {
+    return mappers.onNone();
+  } else {
+    if (hasError(result)) {
+      return mappers.onError(result.error);
+    } else {
+      return mappers.onData(result.data);
+    }
+  }
 }
 
 // Handle all loading / data cases of a remote and return a single value.
@@ -105,15 +151,11 @@ export function squash<T, E, R>(
     onError: (error: E, loading: boolean) => R;
   }
 ): R {
-  if (remoteResult.result === undefined) {
-    return mappers.onNone(remoteResult.loading);
-  } else {
-    if (hasError(remoteResult.result)) {
-      return mappers.onError(remoteResult.result.error, remoteResult.loading);
-    } else {
-      return mappers.onData(remoteResult.result.data, remoteResult.loading);
-    }
-  }
+  return handle(remoteResult.result, {
+    onNone: () => mappers.onNone(remoteResult.loading),
+    onData: data => mappers.onData(data, remoteResult.loading),
+    onError: error => mappers.onError(error, remoteResult.loading),
+  });
 }
 
 // Set parent[key] to newValue unless exising value is deeply equal.


### PR DESCRIPTION
This prevents the unnecessary rerendering for Firestore.