### PR TITLE
Tweak overview spacing/fonts

### DIFF
--- a/src/components/Home/LocalWarningCallout.tsx
+++ b/src/components/Home/LocalWarningCallout.tsx
@@ -36,7 +36,7 @@ export const LocalWarningCallout: React.FC<{
           </>
         }
       >
-        Remember this is a local enivornment. Visit the production version of{' '}
+        Remember this is a local environment. Visit the production version of{' '}
         <strong>{projectId}</strong> in the console.
       </Callout>
     </GridCell>

--- a/src/components/Home/index.scss
+++ b/src/components/Home/index.scss
@@ -2,10 +2,17 @@
   h4 {
     margin-bottom: 0;
   }
+
+  .title {
+    margin-top: 8px;
+    display: flex;
+    align-items: center;
+
+    .rmwc-icon {
+      margin-right: 8px;
+    }
+  }
 }
 .Home-EmulatorCard-Info {
   margin: 16px;
-}
-.Home-EmulatorCard-Action {
-  padding: 16px;
 }

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -19,7 +19,6 @@ import './index.scss';
 import {
   Card,
   CardActionButton,
-  CardActionButtons,
   CardActionIcons,
   CardActions,
 } from '@rmwc/card';

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -16,7 +16,13 @@
 
 import './index.scss';
 
-import { Card, CardActionButton, CardActionIcons } from '@rmwc/card';
+import {
+  Card,
+  CardActionButton,
+  CardActionButtons,
+  CardActionIcons,
+  CardActions,
+} from '@rmwc/card';
 import { GridCell } from '@rmwc/grid';
 import { ListDivider } from '@rmwc/list';
 import { Typography } from '@rmwc/typography';
@@ -97,16 +103,16 @@ export const EmulatorCard: React.FC<{
   <GridCell span={4}>
     <Card className="Home-EmulatorCard" data-testid={testId}>
       <div className="Home-EmulatorCard-Info">
-        <Typography use="headline6" tag="h3">
+        <Typography use="headline6" tag="h3" className="title">
           {icon} {name}
         </Typography>
-        <Typography use="subtitle2" tag="h4">
+        <Typography use="body2" tag="h4" theme="secondary">
           Status
         </Typography>
         <Typography use="headline6" tag="div">
           {config ? 'On' : 'Off'}
         </Typography>
-        <Typography use="subtitle2" tag="h4">
+        <Typography use="body2" tag="h4" theme="secondary">
           Port number
         </Typography>
         <Typography use="headline6" tag="div">
@@ -114,11 +120,13 @@ export const EmulatorCard: React.FC<{
         </Typography>
       </div>
       <ListDivider />
-      <CardActionIcons className="Home-EmulatorCard-Action">
-        <CardActionButton tag={props => <Link to={linkTo} {...props} />}>
-          {linkLabel || 'Go to Emulator'}
-        </CardActionButton>
-      </CardActionIcons>
+      <CardActions>
+        <CardActionIcons>
+          <CardActionButton tag={props => <Link to={linkTo} {...props} />}>
+            {linkLabel || 'Go to Emulator'}
+          </CardActionButton>
+        </CardActionIcons>
+      </CardActions>
     </Card>
   </GridCell>
 );


### PR DESCRIPTION
* Align icons better
* heading color secondary, and lighter font weight
* more consistent card action padding.

<img width="819" alt="Screen Shot 2020-03-31 at 4 22 59 PM" src="https://user-images.githubusercontent.com/702990/78083992-e6da9100-736b-11ea-9f96-d8c26e517e11.png">


* Typo on environment in callout

<img width="810" alt="Screen Shot 2020-03-31 at 4 25 30 PM" src="https://user-images.githubusercontent.com/702990/78084138-4b95eb80-736c-11ea-97d1-06f15ef7c568.png">
