### PR TITLE
Deduplicate logs.

### DIFF
--- a/src/components/LogViewer/index.tsx
+++ b/src/components/LogViewer/index.tsx
@@ -71,7 +71,7 @@ export const LogViewer: React.FC<Props> = ({
       logReceived(log);
     };
     return () => webSocket.cleanup();
-  }, [config, logReceived]);
+  }, [config, logReceived, logReset]);
 
   const parsedQuery = parseQuery(query);
 

--- a/src/components/LogViewer/index.tsx
+++ b/src/components/LogViewer/index.tsx
@@ -24,7 +24,12 @@ import { connect } from 'react-redux';
 
 import { AppState } from '../../store';
 import { LoggingConfig } from '../../store/config';
-import { LogEntry, LogState } from '../../store/logviewer';
+import {
+  LogEntry,
+  LogState,
+  logReceived,
+  logReset,
+} from '../../store/logviewer';
 import { hasData } from '../../store/utils';
 import { CompiledGetterCache } from './CompiledGetterCache';
 import History from './History';
@@ -38,18 +43,24 @@ interface PropsFromState {
 
 interface PropsFromDispatch {
   logReceived: Function;
+  logReset: () => void;
 }
 
 export type Props = PropsFromState & PropsFromDispatch;
 
 const compiledGetters = new CompiledGetterCache();
 
-export const LogViewer: React.FC<Props> = ({ logReceived, config }) => {
+export const LogViewer: React.FC<Props> = ({
+  logReceived,
+  logReset,
+  config,
+}) => {
   const [query, setQuery] = useState('');
 
   useEffect(() => {
     if (!config) return;
 
+    logReset();
     const webSocket = new ReconnectingWebSocket(config);
     webSocket.listener = (log: LogEntry) => {
       //todo: remove hack to cut off icon
@@ -58,11 +69,8 @@ export const LogViewer: React.FC<Props> = ({ logReceived, config }) => {
         .slice(1)
         .join(' ');
       logReceived(log);
-
-      return () => {
-        webSocket.listener = undefined;
-      };
     };
+    return () => webSocket.cleanup();
   }, [config, logReceived]);
 
   const parsedQuery = parseQuery(query);
@@ -94,9 +102,8 @@ export const mapStateToProps = ({ config }: AppState) => {
   };
 };
 export const mapDispatchToProps = {
-  logReceived(log: LogEntry) {
-    return { type: '@log/RECEIVED', payload: log };
-  },
+  logReceived,
+  logReset,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(LogViewer);

--- a/src/store/logviewer/actions.ts
+++ b/src/store/logviewer/actions.ts
@@ -19,3 +19,6 @@ import { createAction } from 'typesafe-actions';
 import { LogEntry } from './types';
 
 export const logReceived = createAction('@log/RECEIVED')<LogEntry>();
+
+// TODO: Remove this hack once it's not needed.
+export const logReset = createAction('@log/REST')();

--- a/src/store/logviewer/actions.ts
+++ b/src/store/logviewer/actions.ts
@@ -21,4 +21,4 @@ import { LogEntry } from './types';
 export const logReceived = createAction('@log/RECEIVED')<LogEntry>();
 
 // TODO: Remove this hack once it's not needed.
-export const logReset = createAction('@log/REST')();
+export const logReset = createAction('@log/RESET')();

--- a/src/store/logviewer/reducer.ts
+++ b/src/store/logviewer/reducer.ts
@@ -16,11 +16,15 @@
 
 import { Action, createReducer } from 'typesafe-actions';
 
-import { logReceived } from './actions';
+import { logReceived, logReset } from './actions';
 import { LogState } from './types';
 
 export const logReducer = createReducer<LogState, Action>({
   history: [],
-}).handleAction(logReceived, (state: LogState, { payload }) => {
-  return { ...state, history: [...state.history, payload] };
-});
+})
+  .handleAction(logReceived, (state: LogState, { payload }) => {
+    return { ...state, history: [...state.history, payload] };
+  })
+  .handleAction(logReset, (state: LogState) => {
+    return { ...state, history: [] };
+  });


### PR DESCRIPTION
This PR contains two changes to fix duplicate logs.

1. Remove duplicate log history when navigating to Logs tab, navigate away, and then navigate back. This is because the WebSocket connection always send over all existing logs even on reconnect.
2. Fix cleanup for the socket connection to prevent memory leak and also removes duplicate listeners. This fixes an issue where the same new log will appear more than one time.

The fixes here are temporary to get the GUI into a better state while we're waiting for pending refactors to move websockets into sagas.