### PR TITLE
Configure Renovate to send us PRs for minor version changes.

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,7 +4,6 @@
 {
   extends: [
     "config:base",
-    ":preserveSemverRanges",
   ],
   packageRules: [
     {
@@ -34,4 +33,7 @@
     },
     // END version constraints for Node.js 8 support.
   ],
+  // Update package-lock.json when in-range updates are available, otherwise replace
+  // the range in package.json for updates out of range.
+  rangeStrategy: "update-lockfile",
 }


### PR DESCRIPTION
Before we didn't get many updates since they're all in range. This PR tells Renovate to try to update them via package-lock.json changes.