### PR TITLE
Remove await wait() in favor of better approaches.

### DIFF
--- a/src/components/App/AppBar.test.tsx
+++ b/src/components/App/AppBar.test.tsx
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
+import { render } from '@testing-library/react';
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import { MemoryRouter } from 'react-router-dom';
 
-import { renderAndWait } from '../../test_utils';
+import { delay } from '../../test_utils';
 import { AppBar } from './AppBar';
 
 function isTabActive(labelEl: HTMLElement) {
@@ -26,7 +28,7 @@ function isTabActive(labelEl: HTMLElement) {
 }
 
 it('selects the matching nav-tab', async () => {
-  const { getByText } = await renderAndWait(
+  const { getByText } = render(
     <MemoryRouter initialEntries={['/bar']}>
       <AppBar
         routes={[
@@ -48,6 +50,8 @@ it('selects the matching nav-tab', async () => {
       />
     </MemoryRouter>
   );
+
+  await act(() => delay(300)); // Wait for tab indicator async DOM updates.
 
   expect(isTabActive(getByText('foo'))).toBe(false);
   expect(isTabActive(getByText('bar'))).toBe(true);

--- a/src/components/App/index.test.tsx
+++ b/src/components/App/index.test.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { render } from '@testing-library/react';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
@@ -21,7 +22,7 @@ import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 
 import configureStore from '../../configureStore';
-import { delay, renderAndWait, waitForDialogsToOpen } from '../../test_utils';
+import { delay, waitForDialogsToOpen } from '../../test_utils';
 import { alert } from '../common/DialogQueue';
 import App from '.';
 
@@ -45,13 +46,15 @@ it('renders without crashing', async () => {
 
 it('shows dialogs in the queue', async () => {
   const store = configureStore();
-  const { getByText } = await renderAndWait(
+  const { getByText } = render(
     <Provider store={store}>
       <BrowserRouter>
         <App />
       </BrowserRouter>
     </Provider>
   );
+
+  await act(() => delay(100)); // Wait for tab indicator async DOM updates.
 
   act(() => {
     alert({ title: 'wowah' });

--- a/src/components/App/index.test.tsx
+++ b/src/components/App/index.test.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { render } from '@testing-library/react';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
@@ -22,7 +21,7 @@ import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 
 import configureStore from '../../configureStore';
-import { delay, renderAndWait } from '../../test_utils';
+import { delay, renderAndWait, waitForDialogsToOpen } from '../../test_utils';
 import { alert } from '../common/DialogQueue';
 import App from '.';
 
@@ -57,6 +56,8 @@ it('shows dialogs in the queue', async () => {
   act(() => {
     alert({ title: 'wowah' });
   });
+
+  await waitForDialogsToOpen();
 
   expect(getByText('wowah')).not.toBeNull();
 });

--- a/src/components/Database/DataViewer/CloneDialog.test.tsx
+++ b/src/components/Database/DataViewer/CloneDialog.test.tsx
@@ -14,16 +14,10 @@
  * limitations under the License.
  */
 
-import {
-  RenderResult,
-  act,
-  fireEvent,
-  render,
-  wait,
-} from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import React from 'react';
 
-import { delay, renderAndWait } from '../../../test_utils';
+import { delay, renderDialog } from '../../../test_utils';
 import { fakeReference } from '../testing/models';
 import { CloneDialog } from './CloneDialog';
 
@@ -39,7 +33,7 @@ const setup = async () => {
   ref.child.mockReturnValue(ref);
   parent.child.mockReturnValue(ref);
 
-  const { getByText, getByLabelText, getByTestId } = await renderAndWait(
+  const { getByText, getByLabelText, getByTestId } = await renderDialog(
     <CloneDialog onComplete={onComplete} realtimeRef={ref} />
   );
   return { ref, parent, onComplete, getByLabelText, getByText, getByTestId };
@@ -108,8 +102,9 @@ it('clones dialog data when the dialog is accepted', async () => {
     });
   });
 
-  act(() => {
+  await act(async () => {
     fireEvent.submit(getByText('Clone'));
+    await delay(100); // Wait for the dialog DOM changes to settle.
   });
 
   expect(parent.child).toHaveBeenCalledWith('to_clone_copy');

--- a/src/components/Firestore/CollectionList.test.tsx
+++ b/src/components/Firestore/CollectionList.test.tsx
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-import { render, wait } from '@testing-library/react';
+import { act, render, wait } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
+import { makeDeferred, renderAndWait } from '../../test_utils';
 import DatabaseApi from './api';
 import { ApiProvider } from './ApiContext';
 import CollectionList from './CollectionList';
 import {
+  FakeCollectionReference,
   fakeCollectionReference,
   fakeDocumentReference,
   fakeDocumentSnapshot,
@@ -32,12 +34,10 @@ jest.mock('./api');
 
 it('shows the list of collections', async () => {
   const fakeApi = new DatabaseApi();
-  fakeApi.getCollections.mockResolvedValueOnce([
-    fakeCollectionReference({ id: 'coll-1' }),
-    fakeCollectionReference({ id: 'coll-2' }),
-  ]);
+  const getCollections = makeDeferred<FakeCollectionReference[]>();
+  fakeApi.getCollections.mockReturnValueOnce(getCollections.promise);
 
-  const { getByText, queryByText } = render(
+  const { getByText } = await render(
     <MemoryRouter>
       <ApiProvider value={fakeApi}>
         <CollectionList />
@@ -45,8 +45,12 @@ it('shows the list of collections', async () => {
     </MemoryRouter>
   );
 
-  await wait();
-
+  await act(() =>
+    getCollections.resolve([
+      fakeCollectionReference({ id: 'coll-1' }),
+      fakeCollectionReference({ id: 'coll-2' }),
+    ])
+  );
   expect(getByText(/coll-1/)).not.toBeNull();
   expect(getByText(/coll-2/)).not.toBeNull();
 });
@@ -54,15 +58,13 @@ it('shows the list of collections', async () => {
 it('requests root-collections with no docRef', async () => {
   const fakeApi = new DatabaseApi();
 
-  const { getByText, queryByText } = render(
+  await renderAndWait(
     <MemoryRouter>
       <ApiProvider value={fakeApi}>
         <CollectionList />
       </ApiProvider>
     </MemoryRouter>
   );
-
-  await wait();
 
   expect(fakeApi.getCollections).toHaveBeenCalledWith(undefined);
 });
@@ -71,15 +73,13 @@ it('requests sub-collections with docRef', async () => {
   const fakeApi = new DatabaseApi();
   const fakeDocRef = fakeDocumentReference();
 
-  const { getByText, queryByText } = render(
+  await renderAndWait(
     <MemoryRouter>
       <ApiProvider value={fakeApi}>
         <CollectionList reference={fakeDocRef} />
       </ApiProvider>
     </MemoryRouter>
   );
-
-  await wait();
 
   expect(fakeApi.getCollections).toHaveBeenCalledWith(fakeDocRef);
 });

--- a/src/components/Firestore/CollectionList.test.tsx
+++ b/src/components/Firestore/CollectionList.test.tsx
@@ -18,7 +18,7 @@ import { act, render, wait } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
-import { makeDeferred, renderAndWait } from '../../test_utils';
+import { delay, makeDeferred } from '../../test_utils';
 import DatabaseApi from './api';
 import { ApiProvider } from './ApiContext';
 import CollectionList from './CollectionList';
@@ -58,13 +58,15 @@ it('shows the list of collections', async () => {
 it('requests root-collections with no docRef', async () => {
   const fakeApi = new DatabaseApi();
 
-  await renderAndWait(
+  render(
     <MemoryRouter>
       <ApiProvider value={fakeApi}>
         <CollectionList />
       </ApiProvider>
     </MemoryRouter>
   );
+
+  await act(() => delay(100)); // Give it some time to call getCollections.
 
   expect(fakeApi.getCollections).toHaveBeenCalledWith(undefined);
 });
@@ -73,13 +75,15 @@ it('requests sub-collections with docRef', async () => {
   const fakeApi = new DatabaseApi();
   const fakeDocRef = fakeDocumentReference();
 
-  await renderAndWait(
+  render(
     <MemoryRouter>
       <ApiProvider value={fakeApi}>
         <CollectionList reference={fakeDocRef} />
       </ApiProvider>
     </MemoryRouter>
   );
+
+  await act(() => delay(100)); // Give it some time to call getCollections.
 
   expect(fakeApi.getCollections).toHaveBeenCalledWith(fakeDocRef);
 });

--- a/src/components/Firestore/CollectionList.test.tsx
+++ b/src/components/Firestore/CollectionList.test.tsx
@@ -37,7 +37,7 @@ it('shows the list of collections', async () => {
   const getCollections = makeDeferred<FakeCollectionReference[]>();
   fakeApi.getCollections.mockReturnValueOnce(getCollections.promise);
 
-  const { getByText } = await render(
+  const { getByText } = render(
     <MemoryRouter>
       <ApiProvider value={fakeApi}>
         <CollectionList />

--- a/src/components/Firestore/DocumentEditor/index.test.tsx
+++ b/src/components/Firestore/DocumentEditor/index.test.tsx
@@ -190,8 +190,7 @@ describe('changing types', () => {
     await act(async () => {
       setType(FieldType.ARRAY);
     });
-    await wait();
-    expect(getAllByText('add').length).toBe(2);
+    await wait(() => expect(getAllByText('add').length).toBe(2));
   });
 
   it('switches to a boolean', async () => {

--- a/src/components/Firestore/DocumentPreview/index.test.tsx
+++ b/src/components/Firestore/DocumentPreview/index.test.tsx
@@ -14,18 +14,11 @@
  * limitations under the License.
  */
 
-import {
-  RenderResult,
-  act,
-  fireEvent,
-  render,
-  wait,
-} from '@testing-library/react';
+import { RenderResult, act, fireEvent, render } from '@testing-library/react';
 import { firestore } from 'firebase';
 import React from 'react';
 import { useDocumentData } from 'react-firebase-hooks/firestore';
 
-import { renderAndWait } from '../../../test_utils';
 import { fakeDocumentReference } from '../testing/models';
 import DocumentPreview from './index';
 
@@ -53,9 +46,7 @@ describe('loaded document', () => {
     ]);
     documentReference = fakeDocumentReference();
 
-    result = await renderAndWait(
-      <DocumentPreview reference={documentReference} />
-    );
+    result = render(<DocumentPreview reference={documentReference} />);
   });
 
   it('adds a new field', () => {

--- a/src/components/Firestore/dialogs/AddCollectionDialog.test.tsx
+++ b/src/components/Firestore/dialogs/AddCollectionDialog.test.tsx
@@ -18,7 +18,11 @@ import { RenderResult, fireEvent, render, wait } from '@testing-library/react';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
-import { delay, renderAndWait } from '../../../test_utils';
+import {
+  delay,
+  renderDialog,
+  waitForDialogsToClose,
+} from '../../../test_utils';
 import DatabaseApi from '../api';
 import {
   fakeCollectionReference,
@@ -61,8 +65,8 @@ it('shows correct title', () => {
 });
 
 describe('step 1', () => {
-  it('displays the parent document path', () => {
-    const { getByLabelText } = render(
+  it('displays the parent document path', async () => {
+    const { getByLabelText } = await renderDialog(
       <AddCollectionDialog
         open={true}
         api={api}
@@ -75,7 +79,7 @@ describe('step 1', () => {
   });
 
   it('contains a collection id input', async () => {
-    const { getByLabelText } = await renderAndWait(
+    const { getByLabelText } = await renderDialog(
       <AddCollectionDialog open={true} api={api} onValue={() => {}} />
     );
 
@@ -89,7 +93,7 @@ describe('step 2', () => {
 
   beforeEach(async () => {
     onValue = jest.fn();
-    result = await renderAndWait(
+    result = await renderDialog(
       <AddCollectionDialog
         open={true}
         api={api}
@@ -151,8 +155,7 @@ describe('step 2', () => {
     });
 
     act(() => getByText('Save').click());
-
-    await wait();
+    await waitForDialogsToClose();
 
     expect(onValue).toHaveBeenCalledWith({
       collectionId: 'my-col',
@@ -167,16 +170,15 @@ describe('step 2', () => {
     const { getByText } = result;
 
     act(() => getByText('Cancel').click());
-
-    await wait();
+    await waitForDialogsToClose();
 
     expect(onValue).toHaveBeenCalledWith(null);
   });
 }); // step 2
 
 describe('at the root of the db', () => {
-  it('shows the correct parent path', () => {
-    const { getByLabelText } = render(
+  it('shows the correct parent path', async () => {
+    const { getByLabelText } = await renderDialog(
       <AddCollectionDialog open={true} api={api} onValue={() => {}} />
     );
 

--- a/src/components/Firestore/dialogs/AddDocumentDialog.test.tsx
+++ b/src/components/Firestore/dialogs/AddDocumentDialog.test.tsx
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { fireEvent, render, wait } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { fireEvent, wait } from '@testing-library/react';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
+import { renderDialog, waitForDialogsToClose } from '../../../test_utils';
 import {
   fakeCollectionReference,
   fakeDocumentReference,
@@ -36,58 +36,50 @@ const collectionReference = fakeCollectionReference({
 collectionReference.doc.mockReturnValue(docRef);
 
 it('shows correct title', async () => {
-  const { getByText } = render(
+  const { getByText } = await renderDialog(
     <AddDocumentDialog
       open={true}
       collectionRef={collectionReference}
       onValue={() => {}}
     />
   );
-
-  await wait();
 
   expect(getByText(/Add a document/)).not.toBeNull();
 });
 
 it('shows the (disabled) creation path', async () => {
-  const { getByLabelText } = render(
+  const { getByLabelText } = await renderDialog(
     <AddDocumentDialog
       open={true}
       collectionRef={collectionReference}
       onValue={() => {}}
     />
   );
-
-  await wait();
 
   expect(getByLabelText('Parent path').value).toBe('users/bob/my-stuff');
   expect(getByLabelText('Parent path').disabled).toBe(true);
 });
 
 it('auto generates an id', async () => {
-  const { getByLabelText } = render(
+  const { getByLabelText } = await renderDialog(
     <AddDocumentDialog
       open={true}
       collectionRef={collectionReference}
       onValue={() => {}}
     />
   );
-
-  await wait();
 
   expect(getByLabelText('Document ID').value).toBe('random-identifier');
 });
 
 it('provides a document-editor', async () => {
-  const { getByLabelText } = render(
+  const { getByLabelText } = await renderDialog(
     <AddDocumentDialog
       open={true}
       collectionRef={collectionReference}
       onValue={() => {}}
     />
   );
-
-  await wait();
 
   expect(getByLabelText('Field')).not.toBe(null);
 });
@@ -97,7 +89,7 @@ it('provides a document-editor', async () => {
 // reproducible in the actual GUI.
 it.skip('[Save] is disabled with invalid doc-data', async () => {
   const onValue = jest.fn();
-  const { getByText, getByLabelText } = render(
+  const { getByText, getByLabelText } = await renderDialog(
     <AddDocumentDialog
       open={true}
       collectionRef={collectionReference}
@@ -114,7 +106,7 @@ it.skip('[Save] is disabled with invalid doc-data', async () => {
 
 it('emits id and parsed data when [Save] is clicked', async () => {
   const onValue = jest.fn();
-  const { getByText, getByLabelText } = render(
+  const { getByText, getByLabelText } = await renderDialog(
     <AddDocumentDialog
       open={true}
       collectionRef={collectionReference}
@@ -136,8 +128,7 @@ it('emits id and parsed data when [Save] is clicked', async () => {
 
   act(() => getByText('Save').click());
 
-  await wait();
-  await wait();
+  await waitForDialogsToClose();
 
   expect(onValue).toHaveBeenCalledWith({
     id: 'new-document-id',
@@ -147,7 +138,7 @@ it('emits id and parsed data when [Save] is clicked', async () => {
 
 it('emits null when [Cancel] is clicked', async () => {
   const onValue = jest.fn();
-  const { getByText, getByLabelText } = render(
+  const { getByText, getByLabelText } = await renderDialog(
     <AddDocumentDialog
       open={true}
       collectionRef={collectionReference}
@@ -163,8 +154,7 @@ it('emits null when [Cancel] is clicked', async () => {
 
   act(() => getByText('Cancel').click());
 
-  await wait();
-  await wait(); // gets rid of some act warning flakes (eww, sorry)
+  await waitForDialogsToClose();
 
   expect(onValue).toHaveBeenCalledWith(null);
 });

--- a/src/components/Firestore/index.test.tsx
+++ b/src/components/Firestore/index.test.tsx
@@ -14,15 +14,19 @@
  * limitations under the License.
  */
 
-import { act, render, wait } from '@testing-library/react';
+import { RenderResult, act, render, wait } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter, Route } from 'react-router-dom';
 
 import { FirestoreConfig } from '../../store/config';
+import { makeDeferred } from '../../test_utils';
 import { confirm } from '../common/DialogQueue';
 import DatabaseApi from './api';
 import { Firestore, FirestoreRoute } from './index';
-import { fakeCollectionReference } from './testing/models';
+import {
+  FakeCollectionReference,
+  fakeCollectionReference,
+} from './testing/models';
 
 jest.mock('./api');
 jest.mock('../common/DialogQueue');
@@ -77,16 +81,23 @@ describe('FirestoreRoute', () => {
 
 describe('Firestore', () => {
   it('shows the top-level collections', async () => {
-    DatabaseApi.prototype.getCollections.mockResolvedValue([
-      fakeCollectionReference({ id: 'cool-coll' }),
-    ]);
-    const { getByText, queryByText } = render(
-      <MemoryRouter>
-        <Firestore config={sampleConfig} projectId={'foo'} />
-      </MemoryRouter>
+    let getCollections = makeDeferred<FakeCollectionReference[]>();
+    DatabaseApi.prototype.getCollections.mockReturnValue(
+      getCollections.promise
     );
+    let renderResult!: RenderResult;
+    act(() => {
+      renderResult = render(
+        <MemoryRouter>
+          <Firestore config={sampleConfig} projectId={'foo'} />
+        </MemoryRouter>
+      );
+    });
+    const { getByText, queryByText } = renderResult;
 
-    await wait();
+    await act(() =>
+      getCollections.resolve([fakeCollectionReference({ id: 'cool-coll' })])
+    );
 
     expect(queryByText(/Connecting to Firestore/)).toBeNull();
     expect(getByText(/cool-coll/)).not.toBeNull();
@@ -94,12 +105,8 @@ describe('Firestore', () => {
 
   it('triggers clearing all data', async () => {
     confirm.mockResolvedValueOnce(true);
-    let nukeResolve;
-    const nukeSpy = jest
-      .fn()
-      .mockImplementation(
-        () => new Promise(resolve => (nukeResolve = resolve))
-      );
+    const nuke = makeDeferred<void>();
+    const nukeSpy = jest.fn().mockReturnValueOnce(nuke.promise);
 
     DatabaseApi.mockImplementationOnce(() => ({
       getCollections: jest.fn(),
@@ -120,20 +127,18 @@ describe('Firestore', () => {
 
     act(() => getByText('Clear all data').click());
 
-    await wait();
-
-    expect(nukeSpy).toHaveBeenCalled();
+    await wait(() => expect(nukeSpy).toHaveBeenCalled());
     expect(getByTestId('firestore-loading')).not.toBeNull();
 
-    nukeResolve();
-    await wait();
+    await act(() => nuke.resolve());
 
     expect(queryByTestId('firestore-loading')).toBeNull();
     expect(getByTestId('ROOT')).not.toBeNull();
   });
 
   it('does not trigger clearing all data if dialog is not confirmed', async () => {
-    confirm.mockResolvedValueOnce(false);
+    const confirmDeferred = makeDeferred<boolean>();
+    confirm.mockReturnValueOnce(confirmDeferred.promise);
     const nukeSpy = jest.fn();
 
     DatabaseApi.mockImplementationOnce(() => ({
@@ -150,7 +155,8 @@ describe('Firestore', () => {
 
     act(() => getByText('Clear all data').click());
 
-    await wait();
+    // Simulate the case where user clicked on Cancel in the confirm dialog.
+    await act(() => confirmDeferred.resolve(false));
 
     expect(nukeSpy).not.toHaveBeenCalled();
   });

--- a/src/components/Firestore/index.test.tsx
+++ b/src/components/Firestore/index.test.tsx
@@ -85,15 +85,11 @@ describe('Firestore', () => {
     DatabaseApi.prototype.getCollections.mockReturnValue(
       getCollections.promise
     );
-    let renderResult!: RenderResult;
-    act(() => {
-      renderResult = render(
-        <MemoryRouter>
-          <Firestore config={sampleConfig} projectId={'foo'} />
-        </MemoryRouter>
-      );
-    });
-    const { getByText, queryByText } = renderResult;
+    const { getByText, queryByText } = render(
+      <MemoryRouter>
+        <Firestore config={sampleConfig} projectId={'foo'} />
+      </MemoryRouter>
+    );
 
     await act(() =>
       getCollections.resolve([fakeCollectionReference({ id: 'cool-coll' })])

--- a/src/components/Firestore/useAutoSelect.test.tsx
+++ b/src/components/Firestore/useAutoSelect.test.tsx
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { act, render, wait } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import React from 'react';
 import { Route, Router } from 'react-router-dom';
 
-import { renderAndWait } from '../../test_utils';
+import { delay } from '../../test_utils';
 import { useAutoSelect } from './useAutoSelect';
 
 interface TestData {
@@ -33,21 +33,24 @@ const Test: React.FC<{ list: TestData[] | null }> = ({ list }) => {
 const WITH_CHILDREN = [{ id: 'first' }, { id: 'last' }];
 const EMPTY: Array<{ id: string }> = [];
 
+// TODO: Find some other way to test hooks (e.g. using
+// react-hooks-testing-library) that does not need artificial delays on init.
 describe('useAutoSelect', () => {
   describe('at /firestore', () => {
     it('does not redirect if the list is null', async () => {
       const history = createMemoryHistory({ initialEntries: ['/firestore'] });
-      await renderAndWait(
+      render(
         <Router history={history}>
           <Route path="/firestore">
             <Test list={null} />
           </Route>
         </Router>
       );
+      await act(() => delay(100));
       expect(history.location.pathname).toBe('/firestore');
     });
 
-    it('does not redirect if there is nothing to select', () => {
+    it('does not redirect if there is nothing to select', async () => {
       const history = createMemoryHistory({ initialEntries: ['/firestore'] });
       render(
         <Router history={history}>
@@ -56,10 +59,11 @@ describe('useAutoSelect', () => {
           </Route>
         </Router>
       );
+      await act(() => delay(100));
       expect(history.location.pathname).toBe('/firestore');
     });
 
-    it('does not redirect if there is something selected', () => {
+    it('does not redirect if there is something selected', async () => {
       const history = createMemoryHistory({
         initialEntries: ['/firestore/x'],
       });
@@ -70,18 +74,20 @@ describe('useAutoSelect', () => {
           </Route>
         </Router>
       );
+      await act(() => delay(100));
       expect(history.location.pathname).toBe('/firestore/x');
     });
 
     it('redirects to the first child', async () => {
       const history = createMemoryHistory({ initialEntries: ['/firestore'] });
-      await renderAndWait(
+      render(
         <Router history={history}>
           <Route path="/firestore">
             <Test list={WITH_CHILDREN} />
           </Route>
         </Router>
       );
+      await act(() => delay(100));
       expect(history.location.pathname).toBe('/firestore/first');
     });
   }); // at /firestore
@@ -91,13 +97,14 @@ describe('useAutoSelect', () => {
       const history = createMemoryHistory({
         initialEntries: ['/firestore/users'],
       });
-      await renderAndWait(
+      render(
         <Router history={history}>
           <Route path="/firestore/users">
             <Test list={null} />
           </Route>
         </Router>
       );
+      await act(() => delay(100));
       expect(history.location.pathname).toBe('/firestore/users');
     });
 
@@ -105,13 +112,14 @@ describe('useAutoSelect', () => {
       const history = createMemoryHistory({
         initialEntries: ['/firestore/users'],
       });
-      await renderAndWait(
+      render(
         <Router history={history}>
           <Route path="/firestore/users">
             <Test list={EMPTY} />
           </Route>
         </Router>
       );
+      await act(() => delay(100));
       expect(history.location.pathname).toBe('/firestore/users');
     });
 
@@ -119,13 +127,14 @@ describe('useAutoSelect', () => {
       const history = createMemoryHistory({
         initialEntries: ['/firestore/users/x'],
       });
-      await renderAndWait(
+      render(
         <Router history={history}>
           <Route path="/firestore/users">
             <Test list={EMPTY} />
           </Route>
         </Router>
       );
+      await act(() => delay(100));
       expect(history.location.pathname).toBe('/firestore/users/x');
     });
 
@@ -133,13 +142,14 @@ describe('useAutoSelect', () => {
       const history = createMemoryHistory({
         initialEntries: ['/firestore/users'],
       });
-      await renderAndWait(
+      render(
         <Router history={history}>
           <Route path="/firestore/users">
             <Test list={WITH_CHILDREN} />
           </Route>
         </Router>
       );
+      await act(() => delay(100));
       expect(history.location.pathname).toBe('/firestore/users/first');
     });
   }); // at /firestore/:collectionId
@@ -149,13 +159,14 @@ describe('useAutoSelect', () => {
       const history = createMemoryHistory({
         initialEntries: ['/firestore/users/alice/friends'],
       });
-      await renderAndWait(
+      render(
         <Router history={history}>
           <Route path="/firestore/users/alice/friends">
             <Test list={null} />
           </Route>
         </Router>
       );
+      await act(() => delay(100));
       expect(history.location.pathname).toBe('/firestore/users/alice/friends');
     });
 
@@ -163,13 +174,14 @@ describe('useAutoSelect', () => {
       const history = createMemoryHistory({
         initialEntries: ['/firestore/users/alice/friends'],
       });
-      await renderAndWait(
+      render(
         <Router history={history}>
           <Route path="/firestore/users/alice/friends">
             <Test list={EMPTY} />
           </Route>
         </Router>
       );
+      await act(() => delay(100));
       expect(history.location.pathname).toBe('/firestore/users/alice/friends');
     });
 
@@ -177,13 +189,14 @@ describe('useAutoSelect', () => {
       const history = createMemoryHistory({
         initialEntries: ['/firestore/users/alice/friends/x'],
       });
-      await renderAndWait(
+      render(
         <Router history={history}>
           <Route path="/firestore/users/alice/friends">
             <Test list={EMPTY} />
           </Route>
         </Router>
       );
+      await act(() => delay(100));
       expect(history.location.pathname).toBe(
         '/firestore/users/alice/friends/x'
       );
@@ -193,13 +206,14 @@ describe('useAutoSelect', () => {
       const history = createMemoryHistory({
         initialEntries: ['/firestore/users/alice/friends'],
       });
-      await renderAndWait(
+      render(
         <Router history={history}>
           <Route path="/firestore/users/alice/friends">
             <Test list={WITH_CHILDREN} />
           </Route>
         </Router>
       );
+      await act(() => delay(100));
       expect(history.location.pathname).toBe('/firestore/users/alice/friends');
     });
   }); // elsewhere below /firestore/a/b/x
@@ -209,52 +223,56 @@ describe('useAutoSelect', () => {
       const history = createMemoryHistory({
         initialEntries: ['/'],
       });
-      await renderAndWait(
+      render(
         <Router history={history}>
           <Route path="/">
             <Test list={EMPTY} />
           </Route>
         </Router>
       );
+      await act(() => delay(100));
       expect(history.location.pathname).toBe('/');
     });
     it('does not redirect at /x', async () => {
       const history = createMemoryHistory({
         initialEntries: ['/x'],
       });
-      await renderAndWait(
+      render(
         <Router history={history}>
           <Route path="/x">
             <Test list={EMPTY} />
           </Route>
         </Router>
       );
+      await act(() => delay(100));
       expect(history.location.pathname).toBe('/x');
     });
     it('does not redirect at /x/y', async () => {
       const history = createMemoryHistory({
         initialEntries: ['/x/y'],
       });
-      await renderAndWait(
+      render(
         <Router history={history}>
           <Route path="/x/y">
             <Test list={EMPTY} />
           </Route>
         </Router>
       );
+      await act(() => delay(100));
       expect(history.location.pathname).toBe('/x/y');
     });
     it('does not redirect at /x/y/z', async () => {
       const history = createMemoryHistory({
         initialEntries: ['/x/y/z'],
       });
-      await renderAndWait(
+      render(
         <Router history={history}>
           <Route path="/x/y/z">
             <Test list={EMPTY} />
           </Route>
         </Router>
       );
+      await act(() => delay(100));
       expect(history.location.pathname).toBe('/x/y/z');
     });
   }); // other routes

--- a/src/components/Firestore/useAutoSelect.test.tsx
+++ b/src/components/Firestore/useAutoSelect.test.tsx
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import { render, wait } from '@testing-library/react';
+import { act, render, wait } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import React from 'react';
 import { Route, Router } from 'react-router-dom';
 
+import { renderAndWait } from '../../test_utils';
 import { useAutoSelect } from './useAutoSelect';
 
 interface TestData {
@@ -34,9 +35,9 @@ const EMPTY: Array<{ id: string }> = [];
 
 describe('useAutoSelect', () => {
   describe('at /firestore', () => {
-    it('does not redirect if the list is null', () => {
+    it('does not redirect if the list is null', async () => {
       const history = createMemoryHistory({ initialEntries: ['/firestore'] });
-      render(
+      await renderAndWait(
         <Router history={history}>
           <Route path="/firestore">
             <Test list={null} />
@@ -74,24 +75,23 @@ describe('useAutoSelect', () => {
 
     it('redirects to the first child', async () => {
       const history = createMemoryHistory({ initialEntries: ['/firestore'] });
-      render(
+      await renderAndWait(
         <Router history={history}>
           <Route path="/firestore">
             <Test list={WITH_CHILDREN} />
           </Route>
         </Router>
       );
-      await wait();
       expect(history.location.pathname).toBe('/firestore/first');
     });
   }); // at /firestore
 
   describe('at /firestore/:collectionId', () => {
-    it('does not redirect if the list is null', () => {
+    it('does not redirect if the list is null', async () => {
       const history = createMemoryHistory({
         initialEntries: ['/firestore/users'],
       });
-      render(
+      await renderAndWait(
         <Router history={history}>
           <Route path="/firestore/users">
             <Test list={null} />
@@ -101,11 +101,11 @@ describe('useAutoSelect', () => {
       expect(history.location.pathname).toBe('/firestore/users');
     });
 
-    it('does not redirect if there is nothing to select', () => {
+    it('does not redirect if there is nothing to select', async () => {
       const history = createMemoryHistory({
         initialEntries: ['/firestore/users'],
       });
-      render(
+      await renderAndWait(
         <Router history={history}>
           <Route path="/firestore/users">
             <Test list={EMPTY} />
@@ -115,11 +115,11 @@ describe('useAutoSelect', () => {
       expect(history.location.pathname).toBe('/firestore/users');
     });
 
-    it('does not redirect if there is something selected', () => {
+    it('does not redirect if there is something selected', async () => {
       const history = createMemoryHistory({
         initialEntries: ['/firestore/users/x'],
       });
-      render(
+      await renderAndWait(
         <Router history={history}>
           <Route path="/firestore/users">
             <Test list={EMPTY} />
@@ -133,24 +133,23 @@ describe('useAutoSelect', () => {
       const history = createMemoryHistory({
         initialEntries: ['/firestore/users'],
       });
-      render(
+      await renderAndWait(
         <Router history={history}>
           <Route path="/firestore/users">
             <Test list={WITH_CHILDREN} />
           </Route>
         </Router>
       );
-      await wait();
       expect(history.location.pathname).toBe('/firestore/users/first');
     });
   }); // at /firestore/:collectionId
 
   describe('elsewhere below /firestore/a/b/x', () => {
-    it('does not redirect if the list is null', () => {
+    it('does not redirect if the list is null', async () => {
       const history = createMemoryHistory({
         initialEntries: ['/firestore/users/alice/friends'],
       });
-      render(
+      await renderAndWait(
         <Router history={history}>
           <Route path="/firestore/users/alice/friends">
             <Test list={null} />
@@ -160,11 +159,11 @@ describe('useAutoSelect', () => {
       expect(history.location.pathname).toBe('/firestore/users/alice/friends');
     });
 
-    it('does not redirect if there is nothing to select', () => {
+    it('does not redirect if there is nothing to select', async () => {
       const history = createMemoryHistory({
         initialEntries: ['/firestore/users/alice/friends'],
       });
-      render(
+      await renderAndWait(
         <Router history={history}>
           <Route path="/firestore/users/alice/friends">
             <Test list={EMPTY} />
@@ -174,11 +173,11 @@ describe('useAutoSelect', () => {
       expect(history.location.pathname).toBe('/firestore/users/alice/friends');
     });
 
-    it('does not redirect if there is something selected', () => {
+    it('does not redirect if there is something selected', async () => {
       const history = createMemoryHistory({
         initialEntries: ['/firestore/users/alice/friends/x'],
       });
-      render(
+      await renderAndWait(
         <Router history={history}>
           <Route path="/firestore/users/alice/friends">
             <Test list={EMPTY} />
@@ -194,24 +193,23 @@ describe('useAutoSelect', () => {
       const history = createMemoryHistory({
         initialEntries: ['/firestore/users/alice/friends'],
       });
-      render(
+      await renderAndWait(
         <Router history={history}>
           <Route path="/firestore/users/alice/friends">
             <Test list={WITH_CHILDREN} />
           </Route>
         </Router>
       );
-      await wait();
       expect(history.location.pathname).toBe('/firestore/users/alice/friends');
     });
   }); // elsewhere below /firestore/a/b/x
 
   describe('other routes', () => {
-    it('does not redirect at /', () => {
+    it('does not redirect at /', async () => {
       const history = createMemoryHistory({
         initialEntries: ['/'],
       });
-      render(
+      await renderAndWait(
         <Router history={history}>
           <Route path="/">
             <Test list={EMPTY} />
@@ -220,11 +218,11 @@ describe('useAutoSelect', () => {
       );
       expect(history.location.pathname).toBe('/');
     });
-    it('does not redirect at /x', () => {
+    it('does not redirect at /x', async () => {
       const history = createMemoryHistory({
         initialEntries: ['/x'],
       });
-      render(
+      await renderAndWait(
         <Router history={history}>
           <Route path="/x">
             <Test list={EMPTY} />
@@ -233,11 +231,11 @@ describe('useAutoSelect', () => {
       );
       expect(history.location.pathname).toBe('/x');
     });
-    it('does not redirect at /x/y', () => {
+    it('does not redirect at /x/y', async () => {
       const history = createMemoryHistory({
         initialEntries: ['/x/y'],
       });
-      render(
+      await renderAndWait(
         <Router history={history}>
           <Route path="/x/y">
             <Test list={EMPTY} />
@@ -246,11 +244,11 @@ describe('useAutoSelect', () => {
       );
       expect(history.location.pathname).toBe('/x/y');
     });
-    it('does not redirect at /x/y/z', () => {
+    it('does not redirect at /x/y/z', async () => {
       const history = createMemoryHistory({
         initialEntries: ['/x/y/z'],
       });
-      render(
+      await renderAndWait(
         <Router history={history}>
           <Route path="/x/y/z">
             <Test list={EMPTY} />

--- a/src/test_utils.ts
+++ b/src/test_utils.ts
@@ -36,18 +36,6 @@ export function delay(timeoutMs: number): Promise<void> {
  * - For Dialogs, use renderDialog or waitForDialogsToOpen/Close instead.
  * - To test components that change state based on Promises, use makeDeferred().
  */
-export async function renderAndWait(
-  ui: React.ReactElement,
-  options?: Omit<RenderOptions, 'queries'>
-): Promise<RenderResult> {
-  let renderResult: RenderResult;
-  await act(async () => {
-    renderResult = render(ui, options);
-    // Silence warnings caused by async DOM updates.
-    await delay(200);
-  });
-  return renderResult!;
-}
 
 /**
  * Wait for MDC dialogs to be fully open, so no DOM changes happen outside

--- a/src/test_utils.ts
+++ b/src/test_utils.ts
@@ -19,15 +19,23 @@ import {
   RenderResult,
   act,
   render,
+  waitForDomChange,
+  waitForElement,
+  waitForElementToBeRemoved,
 } from '@testing-library/react';
 
 export function delay(timeoutMs: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, timeoutMs));
 }
 
-// Render a component and wait for some async DOM changes on init.
-// This can be used to silence warnings of changing the DOM outside
-// act(...), e.g. for RMWC <Tab>s or <Dialog>s.
+/**
+ * Render a component and wait for some async DOM changes on init.
+ * This serves as a last resort to silence warnings of changing the DOM outside
+ * act(...), e.g. for RMWC <Tab>s.
+ *
+ * - For Dialogs, use renderDialog or waitForDialogsToOpen/Close instead.
+ * - To test components that change state based on Promises, use makeDeferred().
+ */
 export async function renderAndWait(
   ui: React.ReactElement,
   options?: Omit<RenderOptions, 'queries'>
@@ -36,7 +44,115 @@ export async function renderAndWait(
   await act(async () => {
     renderResult = render(ui, options);
     // Silence warnings caused by async DOM updates.
-    await delay(100);
+    await delay(200);
   });
   return renderResult!;
+}
+
+/**
+ * Wait for MDC dialogs to be fully open, so no DOM changes happen outside
+ * our control and trigger warnings of not wrapped in act(...) etc.
+ */
+export async function waitForDialogsToOpen(container: ParentNode = document) {
+  // TODO: Change to waitFor once we migrate to react-testing-library@10.
+  await waitForElement(() =>
+    container.querySelector('.mdc-dialog--open:not(.mdc-dialog--opening)')
+  );
+}
+
+/**
+ * Wait for MDC dialogs to be fully closed, so no DOM changes happen outside
+ * our control and trigger warnings of not wrapped in act(...) etc.
+ */
+export async function waitForDialogsToClose(container: ParentNode = document) {
+  // TODO: Change to waitFor once we migrate to react-testing-library@10.
+  await waitForElementToBeRemoved(() =>
+    document.querySelector('.mdc-dialog--closing')
+  );
+}
+
+/* Render a component containing a MDC dialog, and wait for the dialog to be
+ * fully open. Silences act(...) warnings from RMWC <Dialog>s.
+ *
+ * This is syntatic sugar for render() and then waitForDialogsToOpen().
+ */
+export async function renderDialog(
+  ui: React.ReactElement,
+  options?: Omit<RenderOptions, 'queries'>
+): Promise<RenderResult> {
+  let renderResult: RenderResult;
+  await act(async () => {
+    renderResult = render(ui, options);
+    await waitForDialogsToOpen(renderResult.container);
+  });
+  return renderResult!;
+}
+
+/**
+ * A controlled wrapper for a Promise which is useful for tests.
+ *
+ * Usage:
+ *
+ * ```
+ * const deferred = makeDeferred();
+ * const objectUnderTest = getObjectUnderTest(deferred.promise);
+ * // assertions about how objectUnderTest behaves in the pending state...
+ * await act(() => deferred.resolve(value));
+ * // assertions about how objectUnderTest behaves in the fulfilled state...
+ * ```
+ *
+ * In another test, you can use reject instead and test for rejected state.
+ */
+export interface Deferred<T> {
+  /** The promise being controlled. Will be resolved when resolve is called and
+   * will be rejected when reject is called.
+   */
+  readonly promise: Promise<T>;
+
+  /**
+   * A helper function to resolve the controlled promise. For convenience, this
+   * function also returns another promise that is always FULFILLED after the
+   * controlled promise is resolved.
+   *
+   * Example Usage: `await act(() => deferred.resolve(x));`.
+   */
+  readonly resolve: (value?: T | PromiseLike<T>) => Promise<void>;
+
+  /**
+   * A helper function to reject the controlled promise. For convenience, this
+   * function also returns another promise that is always FULFILLED after the
+   * controlled promise is rejected.
+   * This is just syntatic sugar for `deferred.resolve(Promise.reject(reason))`
+   *
+   * Example Usage: `await act(() => deferred.resolve(x));`.
+   */
+  readonly reject: (reason?: any) => Promise<void>;
+}
+
+export function makeDeferred<T>(): Deferred<T> {
+  let resolve: (value?: T | PromiseLike<T>) => void;
+  let isResolved = false;
+  const promise = new Promise<T>(res => {
+    resolve = res;
+  });
+  return {
+    promise,
+    resolve(value) {
+      if (isResolved) {
+        fail(
+          'Cannot resolve Deferred since it is already resolved! There is ' +
+            'very likely a mistake in the test that calls resolve/reject twice.'
+        );
+      }
+      isResolved = true;
+      resolve(value);
+      return promise.then(
+        () => undefined,
+        () => undefined
+      );
+    },
+    reject(error) {
+      return this.resolve(Promise.reject(error));
+    },
+  };
 }


### PR DESCRIPTION
WANT_LGTM=all

This PR is a massive refactor to remove `await wait()` in our tests in favor of better ways to test.

From now on, please refrain from `await wait()` at all cost in the tests, for the following reasons:

* `await wait()` is deprecated in the [next major release](https://github.com/testing-library/dom-testing-library/releases/tag/v7.0.0) of `dom-testing-library`.
* `await wait()` is fragile, since it relies implicitly on the next DOM update / tick. Sometimes it even takes more than one `await wait()`, leading to unreadable and undebuggable code. Other times, they make tests flaky.
* `await wait()` is not close to how users interact with the app.
    - Users do not perceive DOM implementation details, instead they perceive things like dialogs opening and closing (through monitors, screen readers, etc.).
    - See the [release notes of dom-testing-library](https://github.com/testing-library/dom-testing-library/releases/tag/v7.0.0) for more rationale and the goal of the whole library.

Instead:
- Use utils in `test_utils.ts` for the specific use cases they cover like Promises and dialogs.
- Use `wait(() => expect(...))` for assertions that eventually should succeed.
- Use `findByXXX` to get elements when they eventually appear in DOM.
    * Or use `waitForElement` if there is no `findByXXX` for that (e.g. class names). (Less ideal.)

As a last resort, we can use `await delay(200)` inside `act()`. It conveys the expectation that the component has complicated initial work / updates that finishes in 200ms, and implicitly asserts that user perception during that time does not matter since they are not expected to interact with the component. In my opinion, this is less ideal than waiting for more direct changes, but still better than `await wait()`.