### PR TITLE
Make log viewer more compact / usable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19359,7 +19359,8 @@
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -19462,7 +19463,8 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -19498,6 +19500,7 @@
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -19514,6 +19517,7 @@
             "mkdirp": {
               "version": "0.5.3",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -19606,6 +19610,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -19674,7 +19679,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -19704,6 +19710,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -19760,11 +19767,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -20557,7 +20566,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -20594,7 +20604,8 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -20603,7 +20614,8 @@
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -20706,7 +20718,8 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -20716,6 +20729,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -20741,6 +20755,7 @@
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -20757,6 +20772,7 @@
             "mkdirp": {
               "version": "0.5.3",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -20849,6 +20865,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -20917,7 +20934,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -20947,6 +20965,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -20964,6 +20983,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -21002,11 +21022,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19359,8 +19359,7 @@
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -19463,8 +19462,7 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -19500,7 +19498,6 @@
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -19517,7 +19514,6 @@
             "mkdirp": {
               "version": "0.5.3",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -19610,7 +19606,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -19679,8 +19674,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -19710,7 +19704,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -19767,13 +19760,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -20566,8 +20557,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -20604,8 +20594,7 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -20614,8 +20603,7 @@
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -20718,8 +20706,7 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -20729,7 +20716,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -20755,7 +20741,6 @@
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -20772,7 +20757,6 @@
             "mkdirp": {
               "version": "0.5.3",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -20865,7 +20849,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -20934,8 +20917,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -20965,7 +20947,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -20983,7 +20964,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -21022,13 +21002,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },

--- a/src/components/LogViewer/HighlightedJSON.scss
+++ b/src/components/LogViewer/HighlightedJSON.scss
@@ -16,12 +16,11 @@
 
 .HighlightedJSON {
   background-color: #fff;
-  border-radius: 5px;
-  border: 1px solid #ddd;
-  margin: 10px 0px 0px 0px;
+  border-left: 1px solid #ddd;
   overflow: auto;
-  padding: 10px;
+  padding: 2px 0px 2px 8px;
   white-space: pre;
+  grid-area: message;
 
   .line {
     div {
@@ -37,9 +36,11 @@
 
     .key {
       color: black;
+      cursor: pointer;
     }
     .value {
       color: #005ae5;
+      cursor: pointer;
     }
   }
 }

--- a/src/components/LogViewer/HighlightedJSON.tsx
+++ b/src/components/LogViewer/HighlightedJSON.tsx
@@ -76,6 +76,10 @@ export const HighlightedJSON: React.FC<Props> = ({
 }) => {
   const lines = JSON.stringify(data, null, 2).split('\n');
 
+  if (lines.length === 1)
+    return <div className="log-message-single">{data}</div>;
+  console.log(lines);
+
   let isObject = false;
 
   let hierarchy: HierarchyReference[] = [

--- a/src/components/LogViewer/HighlightedJSON.tsx
+++ b/src/components/LogViewer/HighlightedJSON.tsx
@@ -78,7 +78,6 @@ export const HighlightedJSON: React.FC<Props> = ({
 
   if (lines.length === 1)
     return <div className="log-message-single">{data}</div>;
-  console.log(lines);
 
   let isObject = false;
 

--- a/src/components/LogViewer/History.scss
+++ b/src/components/LogViewer/History.scss
@@ -15,11 +15,10 @@
  */
 
 .LogHistory {
-  background-color: var(--mdc-theme-surface);
   font-family: monospace;
   font-size: 0.9em;
   overflow: auto;
-  padding: 10px 0px;
+  background-color: white;
 
   .LogHistoryEmpty {
     padding: 0px 10px;
@@ -28,36 +27,37 @@
 
 .log-entry {
   align-items: center;
-  border-bottom: 1px solid #eee;
   display: grid;
-  grid-column-gap: 10px;
-  grid-template-areas: 'timestamp level message expand';
-  grid-template-columns: fit-content(100%) fit-content(100%) 1fr fit-content(
-      100%
-    );
-  grid-template-rows: fit-content(100%) fit-content(100%);
-  padding: 5px 10px;
+  grid-column-gap: 5px;
+  grid-template-areas: 'timestamp level message';
+  grid-template-columns: fit-content(100%) fit-content(100%) 1fr;
+  padding-left: 8px;
+  background-color: var(--mdc-theme-surface);
 
   &:first-child {
-    border-top: 1px solid #eee;
+    border-top: 1px solid var(--mdc-theme-surface);
+  }
+
+  &:nth-last-child(2) {
+    border-bottom: 1px solid #ccc;
   }
 
   .log-timestamp {
     grid-area: timestamp;
     opacity: 0.5;
+    align-self: start;
   }
 
   .log-level {
-    background-color: rgba(0, 0, 0, 0.1);
-    border-radius: 100%;
+    border-radius: 3px;
     color: rgba(0, 0, 0, 1);
     cursor: pointer;
     font-weight: bold;
     grid-area: level;
-    height: 20px;
-    padding: 4px;
+    padding: 0px 3px;
+
+    align-self: start;
     text-align: center;
-    width: 20px;
 
     &.warn {
       background-color: orange;
@@ -77,6 +77,11 @@
     grid-row: 1;
     line-height: 1.2em;
     word-break: break-all;
+    white-space: pre-wrap;
+    border-left: 1px solid #ccc;
+    align-self: stretch;
+    background-color: white;
+    padding: 2px 8px;
   }
 
   .log-message-multi {
@@ -85,8 +90,11 @@
   }
 
   .log-data-rich {
-    display: none;
-    visibility: hidden;
+    display: block;
+    grid-column: 1 / span 4;
+    grid-row: 2;
+    visibility: visible;
+    padding-bottom: 8px;
   }
 
   .log-toggle {

--- a/src/components/LogViewer/History.tsx
+++ b/src/components/LogViewer/History.tsx
@@ -83,7 +83,7 @@ export const History: React.FC<Props> = ({
   return (
     <ThemeProvider options={{ surface: grey100 }} className="LogHistory">
       {history.length ? (
-        history.map((log, index) => (
+        history.slice(-100).map((log, index) => (
           <div id={`log_${index}`} className="log-entry" key={index}>
             <span className="log-timestamp">
               {formatTimestamp(log.timestamp)}
@@ -96,32 +96,13 @@ export const History: React.FC<Props> = ({
             </span>
 
             {getUserData(log) ? (
-              <>
-                <div className="log-message-single">{log.message}</div>
-                <input
-                  className="log-toggle"
-                  type="checkbox"
-                  defaultChecked={true}
-                />
-                <div className="log-data-rich">
-                  <HighlightedJSON
-                    data={log.data.user}
-                    appendToQuery={appendToQuery}
-                    compiledGetters={compiledGetters}
-                  />
-                </div>
-              </>
-            ) : log.message.split('\n').length === 1 ? (
-              <div className="log-message-single">{log.message}</div>
+              <HighlightedJSON
+                data={log.data.user}
+                appendToQuery={appendToQuery}
+                compiledGetters={compiledGetters}
+              />
             ) : (
-              <>
-                <div className="log-message-single">
-                  {log.message.split('\n')[0]}
-                </div>
-                <div className="log-message-multi">
-                  <pre>{log.message}</pre>
-                </div>
-              </>
+              <div className="log-message-single">{log.message}</div>
             )}
           </div>
         ))

--- a/src/components/LogViewer/History.tsx
+++ b/src/components/LogViewer/History.tsx
@@ -53,6 +53,8 @@ interface PropsFromState {
 
 type Props = PropsFromState & PropsFromAttributes;
 
+const MAX_LOG_LINES = 100;
+
 export const History: React.FC<Props> = ({
   parsedQuery,
   setQuery,
@@ -83,7 +85,7 @@ export const History: React.FC<Props> = ({
   return (
     <ThemeProvider options={{ surface: grey100 }} className="LogHistory">
       {history.length ? (
-        history.slice(-100).map((log, index) => (
+        history.slice(-MAX_LOG_LINES).map((log, index) => (
           <div id={`log_${index}`} className="log-entry" key={index}>
             <span className="log-timestamp">
               {formatTimestamp(log.timestamp)}

--- a/src/components/LogViewer/QueryBar.scss
+++ b/src/components/LogViewer/QueryBar.scss
@@ -31,7 +31,7 @@
 
     font-size: 1em;
     font-family: monospace;
-    padding: 15px;
+    padding: 16px 16px 4px 16px;
 
     line-height: 1em;
 

--- a/src/components/LogViewer/index.tsx
+++ b/src/components/LogViewer/index.tsx
@@ -66,7 +66,7 @@ export const LogViewer: React.FC<Props> = ({
       //todo: remove hack to cut off icon
       log.message = log.message
         .split(' ')
-        .slice(1)
+        .slice(2)
         .join(' ');
       logReceived(log);
     };


### PR DESCRIPTION
After using the logsviewer and finding it pretty useless / terrible I decided to take a pass on the CSS and make some changes to see how EAP folks like it...

1) Everything is more compact
2) Highlighted JSON views no longer appear differently than regular text, it appears as inline, highlighted JSON
3) Fixes overly aggressive JSON-ificiation
4) Limits rendered logs to last 100

![Screenshot from 2020-04-13 12-43-46](https://user-images.githubusercontent.com/969070/79144364-74fb4200-7d84-11ea-9ae2-44c518bbed63.png)

Like I said, I'd consider this an experiment to get feedback on, I'll reach out to Nate for a UX pass as this is largely just me iterating from my own experience. 