### PR TITLE
Inline editor improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5172,6 +5172,14 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "aria-hidden": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.1.1.tgz",
+      "integrity": "sha512-M7zYxCcOQPOaxGHoMTKUFD2UNcVFTp9ycrdStLcTPLf8zgTXC3+YcGe+UuzSh5X1BX/0/PtS8xTNy4xyH/6xtw==",
+      "requires": {
+        "tslib": "^1.0.0"
+      }
+    },
     "aria-query": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.0.2.tgz",
@@ -8903,6 +8911,11 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
       }
+    },
+    "focus-lock": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.6.6.tgz",
+      "integrity": "sha512-Dx69IXGCq1qsUExWuG+5wkiMqVM/zGx/reXSJSLogECwp3x6KeNQZ+NAetgxEFpnC41rD8U3+jRCW68+LNzdtw=="
     },
     "focus-trap": {
       "version": "5.1.0",
@@ -15534,6 +15547,14 @@
         "whatwg-fetch": "^3.0.0"
       }
     },
+    "react-clientside-effect": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz",
+      "integrity": "sha512-nRmoyxeok5PBO6ytPvSjKp9xwXg9xagoTK1mMjwnQxqM9Hd7MNPl+LS1bOSOe+CV2+4fnEquc7H/S8QD3q697A==",
+      "requires": {
+        "@babel/runtime": "^7.0.0"
+      }
+    },
     "react-dev-utils": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-10.2.1.tgz",
@@ -15985,6 +16006,32 @@
       "resolved": "https://registry.npmjs.org/react-firebase-hooks/-/react-firebase-hooks-2.1.1.tgz",
       "integrity": "sha512-6ZvAUa5q1JJrTQxCEKCXrP6S/en3B65RAYRYHbbjUh9f1BgKPsxkdaGGBPhGKuVSLUrVqTm8PtpZ/LCtAFogKA=="
     },
+    "react-focus-lock": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.2.1.tgz",
+      "integrity": "sha512-47g0xYcCTZccdzKRGufepY8oZ3W1Qg+2hn6u9SHZ0zUB6uz/4K4xJe7yYFNZ1qT6m+2JDm82F6QgKeBTbjW4PQ==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "focus-lock": "^0.6.6",
+        "prop-types": "^15.6.2",
+        "react-clientside-effect": "^1.2.2",
+        "use-callback-ref": "^1.2.1",
+        "use-sidecar": "^1.0.1"
+      }
+    },
+    "react-focus-on": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.3.0.tgz",
+      "integrity": "sha512-Qbgg2A0YwVuY2g3l5yazzTlHrOC6L4a1P2advANQmdXo7xeAokV5RCtk4sqT0ZoW81LU8IAJCsYzqIdXBBclGg==",
+      "requires": {
+        "aria-hidden": "^1.1.1",
+        "react-focus-lock": "^2.2.1",
+        "react-remove-scroll": "^2.2.0",
+        "react-style-singleton": "^2.0.0",
+        "use-callback-ref": "^1.2.1",
+        "use-sidecar": "^1.0.1"
+      }
+    },
     "react-hook-form": {
       "version": "5.4.2",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-5.4.2.tgz",
@@ -16010,6 +16057,27 @@
         "loose-envify": "^1.4.0",
         "prop-types": "^15.7.2",
         "react-is": "^16.9.0"
+      }
+    },
+    "react-remove-scroll": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.2.0.tgz",
+      "integrity": "sha512-bT29xAkNuhS2tnsxhLNJrmmb6Rn8VsnlOfSoRaKdKi90DbhRcQfJ9vHG1TtgfkCP+rx059vCGIScPZaCWsyIKA==",
+      "requires": {
+        "react-remove-scroll-bar": "^2.0.0",
+        "react-style-singleton": "^2.0.0",
+        "tslib": "^1.0.0",
+        "use-callback-ref": "^1.2.1",
+        "use-sidecar": "^1.0.1"
+      }
+    },
+    "react-remove-scroll-bar": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.0.0.tgz",
+      "integrity": "sha512-HSdWZ+6vV6X1btLRhQlIcFulaMePCyg0Un2oXMmDdq8lK9KPUMSnWYINYWVCdgT35em9hiUaR8frBN1PYYLLpQ==",
+      "requires": {
+        "react-style-singleton": "^2.0.0",
+        "tslib": "^1.0.0"
       }
     },
     "react-router": {
@@ -16280,6 +16348,15 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
+      }
+    },
+    "react-style-singleton": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.0.0.tgz",
+      "integrity": "sha512-1Kw9G/b7EqLspjtiKsC9jtoqkx+RAti+8PmBe47ioKTcdhB3gtaKw2Lc3Hsud/VrXh+QECZKmr2yDCwR7ObNtA==",
+      "requires": {
+        "invariant": "^2.2.4",
+        "tslib": "^1.0.0"
       }
     },
     "read-pkg": {
@@ -18603,6 +18680,23 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+    },
+    "use-callback-ref": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.2.tgz",
+      "integrity": "sha512-s7WLAjMmcgSQ6ocTv93xfljIhpIi6r7f+bH54BX7eP26c0Q+W0iemfFBHYND2cSfaWpweiN0/NVtXVMKRlktdg==",
+      "requires": {
+        "@types/react": "^16.9.11"
+      }
+    },
+    "use-sidecar": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.2.tgz",
+      "integrity": "sha512-287RZny6m5KNMTb/Kq9gmjafi7lQL0YHO1lYolU6+tY1h9+Z3uCtkJJ3OSOq3INwYf2hBryCcDh4520AhJibMA==",
+      "requires": {
+        "detect-node": "^2.0.4",
+        "tslib": "^1.9.3"
+      }
     },
     "util": {
       "version": "0.10.3",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-firebase-hooks": "^2.1.1",
+    "react-focus-on": "^3.3.0",
     "react-hook-form": "^5.1.3",
     "react-redux": "^7.2.0",
     "react-router-dom": "^5.1.2",

--- a/src/components/Database/DataViewer/NodeLeaf.scss
+++ b/src/components/Database/DataViewer/NodeLeaf.scss
@@ -25,10 +25,15 @@ $name: 'NodeLeaf';
   }
 
   .#{$name}__actions {
-    display: none;
+    visibility: hidden;
+  }
+
+  .Firestore-InlineEditor-relative-anchor {
+    position: relative;
+    top: 20px; // offset so it appears below the editing field
   }
 
   &:hover > .#{$name}__actions {
-    display: inline-block;
+    visibility: visible;
   }
 }

--- a/src/components/Database/DataViewer/NodeLeaf.scss
+++ b/src/components/Database/DataViewer/NodeLeaf.scss
@@ -28,14 +28,6 @@ $name: 'NodeLeaf';
     display: none;
   }
 
-  .Firestore-Field-inline-editor {
-    position: absolute;
-    left: -4px;
-    top: 32px;
-    right: -4px;
-    z-index: 2;
-  }
-
   &:hover > .#{$name}__actions {
     display: inline-block;
   }

--- a/src/components/Database/DataViewer/NodeLeaf.scss
+++ b/src/components/Database/DataViewer/NodeLeaf.scss
@@ -12,6 +12,7 @@ $name: 'NodeLeaf';
   height: 32px;
   padding-left: 38px; // alignment with expand/collapse icons
   position: relative;
+  flex-wrap: wrap;
 
   .#{$name}__key,
   .#{$name}__value {
@@ -26,11 +27,19 @@ $name: 'NodeLeaf';
 
   .#{$name}__actions {
     visibility: hidden;
+    flex: 1;
+  }
+
+  .#{$name}__edit-ui {
+    width: 100%; // force flex-wrap
   }
 
   .Firestore-InlineEditor-relative-anchor {
-    position: relative;
-    top: 20px; // offset so it appears below the editing field
+    .Firestore-InlineEditor {
+      left: -8px;
+      right: initial;
+      top: -36px; // float over the key being edited
+    }
   }
 
   &:hover > .#{$name}__actions {

--- a/src/components/Database/DataViewer/NodeLeaf.tsx
+++ b/src/components/Database/DataViewer/NodeLeaf.tsx
@@ -68,15 +68,6 @@ export const NodeLeaf = React.memo<Props>(function NodeLeaf$({
   const showAddButton = !realtimeRef.parent && value === null;
   return (
     <div className="NodeLeaf">
-      {isEditing && (
-        <InlineEditor
-          rtdb
-          value={{ [realtimeRef.key || realtimeRef.toString()]: value }}
-          onCancel={() => setIsEditing(false)}
-          onSave={handleEditSuccess}
-          areRootKeysMutable={false}
-        />
-      )}
       <div className="NodeLeaf__key">
         <NodeLink dbRef={realtimeRef} baseUrl={baseUrl} />
         {': '}
@@ -95,6 +86,15 @@ export const NodeLeaf = React.memo<Props>(function NodeLeaf$({
           <IconButton icon="delete" onClick={handleDelete} />
         </Tooltip>
       </span>
+      {isEditing && (
+        <InlineEditor
+          rtdb
+          value={{ [realtimeRef.key || realtimeRef.toString()]: value }}
+          onCancel={() => setIsEditing(false)}
+          onSave={handleEditSuccess}
+          areRootKeysMutable={false}
+        />
+      )}
       {isAdding && (
         <InlineEditor
           rtdb

--- a/src/components/Database/DataViewer/NodeLeaf.tsx
+++ b/src/components/Database/DataViewer/NodeLeaf.tsx
@@ -94,27 +94,29 @@ export const NodeLeaf = React.memo<Props>(function NodeLeaf$({
           />
         </Tooltip>
       </span>
-      {isEditing && (
-        <InlineEditor
-          rtdb
-          value={{
-            [realtimeRef.key || realtimeRef.toString()]:
-              value === null ? '' : value,
-          }}
-          onCancel={() => setIsEditing(false)}
-          onSave={handleEditSuccess}
-          areRootKeysMutable={false}
-        />
-      )}
-      {isAdding && (
-        <InlineEditor
-          rtdb
-          value={{ [realtimeRef.push().key!]: '' }}
-          onCancel={() => setIsAdding(false)}
-          onSave={handleAddSuccess}
-          areRootKeysMutable={true}
-        />
-      )}
+      <div className="NodeLeaf__edit-ui">
+        {isEditing && (
+          <InlineEditor
+            rtdb
+            value={{
+              [realtimeRef.key || realtimeRef.toString()]:
+                value === null ? '' : value,
+            }}
+            onCancel={() => setIsEditing(false)}
+            onSave={handleEditSuccess}
+            areRootKeysMutable={false}
+          />
+        )}
+        {isAdding && (
+          <InlineEditor
+            rtdb
+            value={{ [realtimeRef.push().key!]: '' }}
+            onCancel={() => setIsAdding(false)}
+            onSave={handleAddSuccess}
+            areRootKeysMutable={true}
+          />
+        )}
+      </div>
     </div>
   );
 });

--- a/src/components/Database/DataViewer/NodeParent.scss
+++ b/src/components/Database/DataViewer/NodeParent.scss
@@ -51,7 +51,11 @@ $name: 'NodeParent';
   }
 
   .Firestore-InlineEditor-relative-anchor {
+    left: 0;
+    margin: 0 20px 0 36px;
     position: absolute;
+    right: 0;
+    top: 36px;
 
     .Firestore-InlineEditor {
       left: -8px;

--- a/src/components/Database/DataViewer/NodeParent.scss
+++ b/src/components/Database/DataViewer/NodeParent.scss
@@ -50,12 +50,13 @@ $name: 'NodeParent';
     }
   }
 
-  .Firestore-Field-inline-editor {
+  .Firestore-InlineEditor-relative-anchor {
     position: absolute;
-    left: -4px;
-    top: 32px;
-    right: -4px;
-    z-index: $ZINDEX_MEDIUM;
+
+    .Firestore-InlineEditor {
+      left: -8px;
+      right: initial;
+    }
   }
 
   .#{$name}__children-container {

--- a/src/components/Database/DataViewer/NodeParent.scss
+++ b/src/components/Database/DataViewer/NodeParent.scss
@@ -1,4 +1,21 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @import '../../common/color';
+@import '../../common/z';
 @import 'common/mixins';
 
 $name: 'NodeParent';
@@ -38,7 +55,7 @@ $name: 'NodeParent';
     left: -4px;
     top: 32px;
     right: -4px;
-    z-index: 2;
+    z-index: $ZINDEX_MEDIUM;
   }
 
   .#{$name}__children-container {

--- a/src/components/Database/DataViewer/common/_mixins.scss
+++ b/src/components/Database/DataViewer/common/_mixins.scss
@@ -1,4 +1,5 @@
 @import '../../../common/color';
+@import '../../../common/z';
 
 @mixin inlineEditCard($baseName) {
   left: 0;
@@ -8,7 +9,7 @@
   top: 0;
 
   &.#{$baseName}__card {
-    z-index: 1000;
+    z-index: $ZINDEX_INLINE_EDITOR;
   }
 
   .#{$baseName}__form-fields {

--- a/src/components/Firestore/DocumentEditor/index.scss
+++ b/src/components/Firestore/DocumentEditor/index.scss
@@ -1,5 +1,5 @@
 .DocumentEditor {
-  overflow: scroll;
+  overflow-y: auto;
 
   .Field {
     width: 136px;

--- a/src/components/Firestore/DocumentPreview/InlineEditor.scss
+++ b/src/components/Firestore/DocumentPreview/InlineEditor.scss
@@ -22,12 +22,11 @@ $container-overhang: 8px;
   position: relative;
 
   .Firestore-InlineEditor {
-    position: absolute;
-    // left: -4px;
-    top: 0;
-    right: -$container-overhang;
-    z-index: $ZINDEX_INLINE_EDITOR;
     min-width: calc(100% + #{2 * $container-overhang});
+    position: absolute;
+    right: -$container-overhang;
+    top: 0;
+    z-index: $ZINDEX_INLINE_EDITOR;
   }
 }
 

--- a/src/components/Firestore/DocumentPreview/InlineEditor.scss
+++ b/src/components/Firestore/DocumentPreview/InlineEditor.scss
@@ -27,7 +27,7 @@ $container-overhang: 8px;
     top: 0;
     right: -$container-overhang;
     z-index: $ZINDEX_INLINE_EDITOR;
-    width: calc(100% + #{2 * $container-overhang});
+    min-width: calc(100% + #{2 * $container-overhang});
   }
 }
 

--- a/src/components/Firestore/DocumentPreview/InlineEditor.tsx
+++ b/src/components/Firestore/DocumentPreview/InlineEditor.tsx
@@ -24,6 +24,7 @@ import {
 } from '@rmwc/card';
 import { Elevation } from '@rmwc/elevation';
 import React, { useState } from 'react';
+import { FocusOn } from 'react-focus-on';
 
 import DocumentEditor from '../DocumentEditor';
 import { FirestoreAny } from '../models';
@@ -45,7 +46,7 @@ const InlineEditor: React.FC<{
     setInternalValue(value);
   }
 
-  function handleCancel(e: React.MouseEvent<HTMLButtonElement>) {
+  function handleCancel() {
     onCancel();
   }
 
@@ -57,33 +58,39 @@ const InlineEditor: React.FC<{
   }
 
   return (
-    <Elevation z={8} wrap>
-      <Card className="Firestore-InlineEditor">
-        <div className="Firestore-InlineEditorContent">
-          <DocumentEditor
-            value={value}
-            onChange={handleChange}
-            areRootNamesMutable={areRootKeysMutable}
-            areRootFieldsMutable={false}
-            rtdb={rtdb}
-            startingIndex={startingIndex}
-            supportNestedArrays={false}
-          />
-        </div>
-        <CardActions className="Firestore-InlineEditorActions">
-          <CardActionButtons>
-            <CardActionButton onClick={handleCancel}>Cancel</CardActionButton>
-            <CardActionButton
-              unelevated
-              onClick={handleSubmit}
-              disabled={!internalValue}
-            >
-              Save
-            </CardActionButton>
-          </CardActionButtons>
-        </CardActions>
-      </Card>
-    </Elevation>
+    <FocusOn
+      className="Firestore-InlineEditor-relative-anchor"
+      onClickOutside={handleCancel}
+      onEscapeKey={handleCancel}
+    >
+      <Elevation z={8} wrap>
+        <Card className="Firestore-InlineEditor">
+          <div className="Firestore-InlineEditorContent">
+            <DocumentEditor
+              value={value}
+              onChange={handleChange}
+              areRootNamesMutable={areRootKeysMutable}
+              areRootFieldsMutable={false}
+              rtdb={rtdb}
+              startingIndex={startingIndex}
+              supportNestedArrays={false}
+            />
+          </div>
+          <CardActions className="Firestore-InlineEditorActions">
+            <CardActionButtons>
+              <CardActionButton onClick={handleCancel}>Cancel</CardActionButton>
+              <CardActionButton
+                unelevated
+                onClick={handleSubmit}
+                disabled={!internalValue}
+              >
+                Save
+              </CardActionButton>
+            </CardActionButtons>
+          </CardActions>
+        </Card>
+      </Elevation>
+    </FocusOn>
   );
 };
 

--- a/src/components/Firestore/index.scss
+++ b/src/components/Firestore/index.scss
@@ -36,13 +36,13 @@
 
 .Firestore-panels-wrapper {
   flex: 1;
-  overflow: hidden;
+  min-width: 0;
 }
 
 .Firestore-panels {
   display: flex;
   flex-direction: row !important;
-  overflow: hidden;
+  min-width: 0;
   flex: 1 1 auto; // grow panels to bottom of card
 }
 
@@ -51,7 +51,7 @@
   display: flex;
   flex-direction: column;
   flex: 1;
-  overflow: hidden;
+  min-width: 0;
 }
 
 .Firestore-Document-List,

--- a/src/components/Firestore/index.scss
+++ b/src/components/Firestore/index.scss
@@ -57,7 +57,7 @@
 .Firestore-Document-List,
 .Firestore-Field-List {
   flex: 1;
-  overflow: auto;
+  min-width: 0;
 }
 
 /** Only show at most 3 panels (Documents/Collections) */

--- a/src/components/common/InteractiveBreadCrumbBar.scss
+++ b/src/components/common/InteractiveBreadCrumbBar.scss
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
+@import '../common/z';
+
 .InteractiveBreadCrumbBar {
-  z-index: 1; // show elevation shadow
+  z-index: $ZINDEX_LOW; // show elevation shadow
 
   .InteractiveBreadCrumbBar-form {
     align-items: center;

--- a/src/components/common/_material-overrides-buttons.scss
+++ b/src/components/common/_material-overrides-buttons.scss
@@ -20,6 +20,7 @@
 @use '@material/button/mdc-button';
 
 @import './components/common/radius';
+@import './components/common/z';
 
 $FOCUS_OUTLINE_THICKNESS: 2px;
 
@@ -88,7 +89,7 @@ $FOCUS_OUTLINE_THICKNESS: 2px;
 
     .mdc-button__label {
       color: $foreColor;
-      z-index: 2; // white text does not get darkened by ::after overlay
+      z-index: $ZINDEX_MEDIUM; // white text does not get darkened by ::after overlay
     }
 
     :before,

--- a/src/components/common/_material-overrides-inputs.scss
+++ b/src/components/common/_material-overrides-inputs.scss
@@ -41,6 +41,7 @@ $input-height: 36px;
 // );
 
 @import './color';
+@import './z';
 
 // TODO: remove below for select 6.0.9
 $mdc-select-height: $input-height;
@@ -82,7 +83,7 @@ $mdc-select-outlined-hover-border: var(--fire-color-input-borders);
 
   .mdc-select__dropdown-icon {
     bottom: $input-default-padding - 2px; // base component doesnt do this yet
-    z-index: 2;
+    z-index: $ZINDEX_MEDIUM;
   }
 }
 

--- a/src/components/common/_z.scss
+++ b/src/components/common/_z.scss
@@ -14,31 +14,22 @@
  * limitations under the License.
  */
 
-@import '../../common/z';
+@import './utils';
 
-$container-overhang: 8px;
+$ZINDEX_LOW: 1;
+$ZINDEX_MEDIUM: 1;
+$ZINDEX_SPINNER: 6;
+$ZINDEX_FEATURE_BAR: 10;
 
-.Firestore-InlineEditor-relative-anchor {
-  position: relative;
+$ZINDEX_INLINE_EDITOR_SCRIM: 39;
+$ZINDEX_INLINE_EDITOR: 40;
 
-  .Firestore-InlineEditor {
-    position: absolute;
-    // left: -4px;
-    top: 0;
-    right: -$container-overhang;
-    z-index: $ZINDEX_INLINE_EDITOR;
-    width: calc(100% + #{2 * $container-overhang});
-  }
-}
+$ZINDEX_CRITICAL_ALERTS: 49;
+$ZINDEX_ALERTS_DRAWER_SCRIM: 51;
+$ZINDEX_ALERTS_DRAWER: 52;
 
-.Firestore-InlineEditor {
-  background-color: var(--mdc-theme-surface);
-}
+// This should be above almost everything
+$ZINDEX_FULL_PAGE_MODAL: 1000;
 
-.Firestore-InlineEditorContent {
-  padding: 8px 16px;
-}
-
-.Firestore-InlineEditorActions {
-  justify-content: flex-end;
-}
+$ZINDEX_UNDER_TOP: 1000;
+$ZINDEX_TOP: 1001;


### PR DESCRIPTION
* Expand to width of parent container (if possible) from top right + 16px overhang
  <img width="682" alt="Screen Shot 2020-04-14 at 2 10 02 PM" src="https://user-images.githubusercontent.com/702990/79274696-d0e3ca80-7e59-11ea-9a3d-239b0bf228dc.png">
  <img width="522" alt="Screen Shot 2020-04-14 at 2 11 02 PM" src="https://user-images.githubusercontent.com/702990/79274703-d2ad8e00-7e59-11ea-8d91-70303ffe5a2a.png">

* Show in DOM at insertion location, and overlay dom elements below
* adjust some z constants, added white background
* Focus trap:
  * adds clickable scrim to close when clicking outside
  * escape closes and clears focus trap
