### PR TITLE
Better inline editor sizes on RTDB

### DIFF
--- a/src/components/Firestore/DocumentPreview/InlineEditor.scss
+++ b/src/components/Firestore/DocumentPreview/InlineEditor.scss
@@ -22,7 +22,6 @@ $container-overhang: 8px;
   position: relative;
 
   .Firestore-InlineEditor {
-    min-width: calc(100% + #{2 * $container-overhang});
     position: absolute;
     right: -$container-overhang;
     top: 0;

--- a/src/components/Firestore/index.scss
+++ b/src/components/Firestore/index.scss
@@ -52,6 +52,13 @@
   flex-direction: column;
   flex: 1;
   min-width: 0;
+
+  .Firestore-InlineEditor-relative-anchor {
+    .Firestore-InlineEditor {
+      // default to the size of the panel + 8px overhang on each side
+      min-width: calc(100% + 16px);
+    }
+  }
 }
 
 .Firestore-Document-List,


### PR DESCRIPTION
Before:

<img width="1305" alt="Screen Shot 2020-04-15 at 12 05 10 PM" src="https://user-images.githubusercontent.com/702990/79377967-5c6c6280-7f11-11ea-9a7c-14df86a76ef8.png">

After:

<img width="621" alt="Screen Shot 2020-04-15 at 12 02 04 PM" src="https://user-images.githubusercontent.com/702990/79377895-41015780-7f11-11ea-8913-cf9dc3b0bcdf.png">

Firestore (no change):

<img width="766" alt="Screen Shot 2020-04-15 at 12 03 50 PM" src="https://user-images.githubusercontent.com/702990/79377841-2cbd5a80-7f11-11ea-9637-a4b3ea508eae.png">
