### PR TITLE
Always show 3 panels

### DIFF
--- a/src/components/Firestore/index.test.tsx
+++ b/src/components/Firestore/index.test.tsx
@@ -99,6 +99,51 @@ describe('Firestore', () => {
     expect(getByText(/cool-coll/)).not.toBeNull();
   });
 
+  it('shows a collection-shell if <2 levels deep ', async () => {
+    let getCollections = makeDeferred<FakeCollectionReference[]>();
+    DatabaseApi.prototype.getCollections.mockReturnValue(
+      getCollections.promise
+    );
+    const { getByTestId } = render(
+      <MemoryRouter initialEntries={['/firebase']}>
+        <Firestore config={sampleConfig} projectId={'foo'} />
+      </MemoryRouter>
+    );
+
+    expect(getByTestId(/collection-shell/)).not.toBeNull();
+    expect(getByTestId(/document-shell/)).not.toBeNull();
+  });
+
+  it('shows a document-shell if <3 levels deep', async () => {
+    let getCollections = makeDeferred<FakeCollectionReference[]>();
+    DatabaseApi.prototype.getCollections.mockReturnValue(
+      getCollections.promise
+    );
+    const { getByTestId, queryByTestId } = render(
+      <MemoryRouter initialEntries={['/firebase/coll']}>
+        <Firestore config={sampleConfig} projectId={'foo'} />
+      </MemoryRouter>
+    );
+
+    expect(queryByTestId(/collection-shell/)).toBeNull();
+    expect(getByTestId(/document-shell/)).not.toBeNull();
+  });
+
+  it('shows no shells if 3 levels deep', async () => {
+    let getCollections = makeDeferred<FakeCollectionReference[]>();
+    DatabaseApi.prototype.getCollections.mockReturnValue(
+      getCollections.promise
+    );
+    const { queryByTestId } = render(
+      <MemoryRouter initialEntries={['/firebase/coll/doc']}>
+        <Firestore config={sampleConfig} projectId={'foo'} />
+      </MemoryRouter>
+    );
+
+    expect(queryByTestId(/collection-shell/)).toBeNull();
+    expect(queryByTestId(/document-shell/)).toBeNull();
+  });
+
   it('triggers clearing all data', async () => {
     confirm.mockResolvedValueOnce(true);
     const nuke = makeDeferred<void>();

--- a/src/components/Firestore/index.tsx
+++ b/src/components/Firestore/index.tsx
@@ -39,6 +39,7 @@ import DatabaseApi from './api';
 import { ApiProvider } from './ApiContext';
 import { promptClearAll } from './dialogs/clearAll';
 import { Root } from './Document';
+import PanelHeader from './PanelHeader';
 import { FirestoreStore } from './store';
 
 export const mapStateToProps = createStructuredSelector({
@@ -80,6 +81,8 @@ export const Firestore: React.FC<FirestoreProps> = ({ config, projectId }) => {
 
   // TODO: do something better here!
   const path = location.pathname.replace(/^\/firestore/, '');
+  const showCollectionShell = path.split('/').length < 3;
+  const showDocumentShell = path.split('/').length < 4;
 
   useEffect(() => {
     const api = new DatabaseApi(projectId, databaseId, config);
@@ -135,6 +138,28 @@ export const Firestore: React.FC<FirestoreProps> = ({ config, projectId }) => {
               />
               <div className="Firestore-panels">
                 <Root />
+                {/*
+                 * TODO: This should really be handled by the constituent Document/Collection components,
+                 * where those components can conditionally show their nested-child. Doing so will be
+                 * easiest once we move to a Suspense-ful render, where we can always show the
+                 * Document/Collection-skeletons, but lazy-render the lists wihin those components.
+                 */}
+                {showCollectionShell && (
+                  <div
+                    className="Firestore-Collection"
+                    data-testid="collection-shell"
+                  >
+                    <PanelHeader id="" icon={null} />
+                  </div>
+                )}
+                {showDocumentShell && (
+                  <div
+                    className="Firestore-Document"
+                    data-testid="document-shell"
+                  >
+                    <PanelHeader id="" icon={null} />
+                  </div>
+                )}
               </div>
             </Card>
           </Elevation>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1452216/81316912-2f1b5c00-905a-11ea-948e-2e67d58526b2.png)

As commented in the code:
This should really be handled by the constituent Document/Collection components, where those components can conditionally show their nested-child. Doing so will be easiest once we move to a Suspense-ful render, where we can always show the Document/Collection-skeletons, but lazy-render the lists within those components.
