### PR TITLE
Ellipsize field previews, fix buttons going offscreen

### DIFF
--- a/src/components/Firestore/DocumentPreview/FieldPreview.scss
+++ b/src/components/Firestore/DocumentPreview/FieldPreview.scss
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import '../../common/utils';
+
 $list-item-padding: 16px;
 $icon-size: 18px;
 $inline-spacing: 8px;
@@ -17,6 +35,10 @@ $inline-spacing: 8px;
 
   &--expanded > .FieldPreview-summary {
     display: none;
+  }
+
+  .FieldPreview-summary {
+    @include ellipsis;
   }
 }
 


### PR DESCRIPTION
This fixes weird text wrapping (b/156022999):

before:
![9MkhEzPHwpw](https://user-images.githubusercontent.com/702990/81347538-34d06c00-9071-11ea-9c7e-3f5d3c097699.png)

after:
<img width="513" alt="Screen Shot 2020-05-07 at 2 41 00 PM" src="https://user-images.githubusercontent.com/702990/81347564-431e8800-9071-11ea-9235-7a330377234a.png">


And buttons going off screen (b/156022902):

![nDL6i8NRfXr](https://user-images.githubusercontent.com/702990/81347604-59c4df00-9071-11ea-9ea3-ddc863b6f77f.png)

after:
<img width="398" alt="Screen Shot 2020-05-07 at 2 41 32 PM" src="https://user-images.githubusercontent.com/702990/81347624-65b0a100-9071-11ea-98dc-108369883694.png">
