### PR TITLE
jest: restoreMocks = true

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     }
   },
   "jest": {
-    "resetMocks": true
+    "resetMocks": true,
+    "restoreMocks": true
   }
 }


### PR DESCRIPTION
More sanity and test isolation.

This restores `jest.spyOn(a, 'b')` mocks, where as `resetMocks` restores just the mock implementation i.e. `.mockReturnedValue(x)`