### PR TITLE
Home card tweaks

### DIFF
--- a/src/components/Home/index.scss
+++ b/src/components/Home/index.scss
@@ -24,7 +24,8 @@
   .title {
     align-items: center;
     display: flex;
-    margin-top: 8px;
+    margin-top: 0;
+    line-height: 1rem;
 
     > span {
       @include ellipsis();
@@ -37,5 +38,5 @@
 }
 
 .Home-EmulatorCard-Info {
-  margin: 16px;
+  margin: 16px 24px;
 }

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -74,18 +74,18 @@ const Overview: React.FC<{
           <Typography use="headline5">Emulator overview</Typography>
         </GridCell>
         <EmulatorCard
-          name="Realtime Database emulator"
-          icon={<DatabaseIcon theme="secondary" />}
-          config={config.database}
-          linkTo="/database"
-          testId="emulator-info-database"
-        />
-        <EmulatorCard
           name="Firestore emulator"
           icon={<FirestoreIcon theme="secondary" />}
           config={config.firestore}
           linkTo="/firestore"
           testId="emulator-info-firestore"
+        />
+        <EmulatorCard
+          name="Realtime Database emulator"
+          icon={<DatabaseIcon theme="secondary" />}
+          config={config.database}
+          linkTo="/database"
+          testId="emulator-info-database"
         />
         <EmulatorCard
           name="Functions emulator"


### PR DESCRIPTION
http://b/156023138

- Padding changed per [this](https://www.figma.com/file/LmqLTVVnwzguVlwztyqiVv/Emulator-Suite-UI?node-id=1929%3A5)
- Firestore moved to first card

<img width="870" alt="Screen Shot 2020-05-15 at 12 34 18 PM" src="https://user-images.githubusercontent.com/702990/82089401-674d1b00-96a8-11ea-8067-ad8753010f56.png">
