### PR TITLE
fix(Realtime Database) Scroll the table view when it's too wide

### DIFF
--- a/src/components/Database/DataViewer/NodeTabularDisplay.scss
+++ b/src/components/Database/DataViewer/NodeTabularDisplay.scss
@@ -1,6 +1,9 @@
 @import '../../common/color';
 
 .NodeTabularDisplay {
+  overflow-x: auto;
+  width: 100%;
+
   .NodeTabularDisplay__key {
     background-color: $COLOR_BACKGROUND_KEY;
     border-radius: 4px;


### PR DESCRIPTION
before:
<img width="848" alt="Screen Shot 2020-05-18 at 1 13 09 PM" src="https://user-images.githubusercontent.com/702990/82255372-5bac5f00-9909-11ea-8079-1045eda63d2c.png">


after:
<img width="877" alt="Screen Shot 2020-05-18 at 1 11 36 PM" src="https://user-images.githubusercontent.com/702990/82255302-43d4db00-9909-11ea-9899-c5563a6aa7ee.png">
