### PR TITLE
Firestore: Encode document id on URI

### DIFF
--- a/src/components/Firestore/Collection.tsx
+++ b/src/components/Firestore/Collection.tsx
@@ -135,7 +135,7 @@ export const Collection: React.FC<Props> = ({ collection }) => {
               key={doc.ref.id}
               className="Firestore-List-Item"
               tag={NavLink}
-              to={`${url}/${doc.ref.id}`}
+              to={`${url}/${encodeURIComponent(doc.ref.id)}`}
               activeClassName="mdc-list-item--activated"
             >
               {doc.ref.id}
@@ -146,7 +146,8 @@ export const Collection: React.FC<Props> = ({ collection }) => {
       <Route
         path={`${url}/:id`}
         render={({ match }: any) => {
-          const docRef = collection.doc(match.params.id);
+          const docId = decodeURIComponent(match.params.id);
+          const docRef = collection.doc(docId);
           return <Document reference={docRef} />;
         }}
       ></Route>

--- a/src/components/Firestore/api.tsx
+++ b/src/components/Firestore/api.tsx
@@ -58,7 +58,10 @@ export default class DatabaseApi extends RestApi implements FirestoreApi {
   private async getSubCollections(
     docRef: firestore.DocumentReference
   ): Promise<firestore.CollectionReference[]> {
-    const encodedPath = docRef.path; // TODO: Encode each segment.
+    const encodedPath = docRef.path
+      .split('/')
+      .map(uri => encodeURIComponent(uri))
+      .join('/');
     const { json } = await this.jsonRequest(
       `${this.baseUrl}/documents/${encodedPath}:listCollectionIds`,
       {},

--- a/src/components/common/BreadCrumbs.tsx
+++ b/src/components/common/BreadCrumbs.tsx
@@ -58,7 +58,7 @@ export const BreadCrumbs: React.FC<Props> = ({
             'BreadCrumbs-active': i === keys.length - 1,
           })}
         >
-          <Link to={hrefs[i]}>{key}</Link>
+          <Link to={hrefs[i]}>{decodeURIComponent(key)}</Link>
         </li>
       ))}
 


### PR DESCRIPTION
Small fix to show firestore documents that contains # and other special characters on the id.