### PR TITLE
Fix redirect on create when nested child is active.

### DIFF
--- a/src/components/Firestore/Collection.tsx
+++ b/src/components/Firestore/Collection.tsx
@@ -80,7 +80,7 @@ export const Collection: React.FC<Props> = ({ collection }) => {
   return (
     <>
       {!loading && redirectIfAutoSelectable}
-      {newDocumentId && <Redirect to={`./${newDocumentId}`} />}
+      {newDocumentId && <Redirect to={`${url}/${newDocumentId}`} />}
       <div className="Firestore-Collection">
         <PanelHeader
           id={collection.id}

--- a/src/components/Firestore/testing/models.ts
+++ b/src/components/Firestore/testing/models.ts
@@ -5,7 +5,8 @@ import { FirestoreApi } from '../models';
 export function fakeDocumentReference({
   id = '',
   path = '',
-  collectionDoc = () => {},
+  collectionDoc = (id: string) =>
+    (undefined as unknown) as firestore.DocumentReference,
 } = {}): firestore.DocumentReference {
   return ({
     id,
@@ -35,17 +36,17 @@ export function fakeDocumentSnapshot({
 }
 
 export type FakeCollectionReference = firestore.CollectionReference & {
-  setSnapshot: (snapshot: firestore.DocumentSnapshot) => void;
+  setSnapshot: (snapshot: firestore.QuerySnapshot) => void;
 };
 
 export function fakeCollectionReference({
   id = '',
-  doc = () => {},
+  doc = (id: string) => (undefined as unknown) as firestore.DocumentReference,
   path = '',
   where = jest.fn(),
   orderBy = jest.fn(),
 } = {}): FakeCollectionReference {
-  let thisObserver = (snapshot: firestore.DocumentSnapshot) => {};
+  let thisObserver = (snapshot: firestore.QuerySnapshot) => {};
 
   return ({
     id,
@@ -55,11 +56,10 @@ export function fakeCollectionReference({
       thisObserver = observer;
       return () => {};
     },
-    setSnapshot: (snapshot: firestore.DocumentSnapshot) =>
-      thisObserver(snapshot),
+    setSnapshot: (snapshot: firestore.QuerySnapshot) => thisObserver(snapshot),
     where,
     orderBy,
-  } as unknown) as FakeCollectionReference;
+  } as Partial<FakeCollectionReference>) as FakeCollectionReference;
 }
 
 export type FakeFirestoreApi = FirestoreApi & {


### PR DESCRIPTION
Steps to repro:

1. Create a nested collection (e.g. `/myColl/a/nested`) and select that collection
2. Create a new document in the parent collection (e.g. `/myColl/b`)

Expected (after PR): The new document in the parent collection is selected
Actual (before PR): Redirects to a wrong URL (`myColl/a/b`)

I also fixed some wrong typings in mocks.