### PR TITLE
Refactor Collection to separate state and presentation.

### DIFF
--- a/src/components/Firestore/Collection.tsx
+++ b/src/components/Firestore/Collection.tsx
@@ -60,9 +60,6 @@ export const Collection: React.FC<Props> = ({ collection }) => {
     filteredCollection
   );
 
-  const [isAddDocumentDialogOpen, setAddDocumentDialogOpen] = useState(false);
-  const [isFilterOpen, setIsFilterOpen] = useState(false);
-
   const { url } = useRouteMatch()!;
   // TODO: Fetch missing documents (i.e. nonexistent docs with subcollections).
   const docs = collectionSnapshot ? collectionSnapshot.docs : NO_DOCS;
@@ -76,11 +73,41 @@ export const Collection: React.FC<Props> = ({ collection }) => {
   };
 
   if (error) return <></>;
+  if (!loading && redirectIfAutoSelectable)
+    return <>{redirectIfAutoSelectable}</>;
+  if (newDocumentId) return <Redirect to={`${url}/${newDocumentId}`} />;
+
+  return (
+    <CollectionPresentation
+      collection={collection}
+      collectionFilter={collectionFilter}
+      addDocument={addDocument}
+      docs={docs}
+      url={url}
+    />
+  );
+};
+
+interface CollectionPresentationProps {
+  collection: firestore.CollectionReference<firestore.DocumentData>;
+  collectionFilter: ReturnType<typeof useCollectionFilter>;
+  addDocument: (value: AddDocumentDialogValue | null) => Promise<void>;
+  docs: firestore.QueryDocumentSnapshot<firestore.DocumentData>[];
+  url: string;
+}
+
+export const CollectionPresentation: React.FC<CollectionPresentationProps> = ({
+  collection,
+  collectionFilter,
+  addDocument,
+  docs,
+  url,
+}) => {
+  const [isFilterOpen, setIsFilterOpen] = useState(false);
+  const [isAddDocumentDialogOpen, setAddDocumentDialogOpen] = useState(false);
 
   return (
     <>
-      {!loading && redirectIfAutoSelectable}
-      {newDocumentId && <Redirect to={`${url}/${newDocumentId}`} />}
       <div className="Firestore-Collection">
         <PanelHeader
           id={collection.id}
@@ -91,7 +118,7 @@ export const Collection: React.FC<Props> = ({ collection }) => {
               open={isFilterOpen}
               onClose={() => setIsFilterOpen(false)}
             >
-              {!loading && isFilterOpen && (
+              {isFilterOpen && (
                 <CollectionFilter
                   className={styles['query-panel']}
                   path={collection.path}
@@ -110,7 +137,6 @@ export const Collection: React.FC<Props> = ({ collection }) => {
           </MenuSurfaceAnchor>
         </PanelHeader>
 
-        {/* Actions */}
         {isAddDocumentDialogOpen && (
           <AddDocumentDialog
             collectionRef={collection}


### PR DESCRIPTION
This PR does two things, first is to split out the CollectionPresentation  (83988e0) into its own component, so we can test presentational things without mocking out API requests and hooks. The second commit (c740d2d) extracts the high order component `withCollectionState` from `Collection`, so that the state handling part can also be tested individually.

One may argue that testing the `withCollectionState` is moving farther from the end user experience and I totally agree. That's why those HOC tests are *unit tests* and they are specifically designed to catch the complex state handling logic without getting into details of an unrelated popup modal. One may in addition write a more black box integration tests if covering the entire flow is desirable.

This pattern is superior to `jest.mock` on the `CollectionPresentation` component since:

* Require mocks require tremendous effort to set up correctly and we've already wasted tons of hours
* This pattern makes the contract clear and is completely type-safe
* Fakes are better than mocks

This is also better than shallow rendering IMO.