### PR TITLE
fix(RTDB): correctly set access token for JSON uploads

### DIFF
--- a/src/components/Database/api.ts
+++ b/src/components/Database/api.ts
@@ -39,7 +39,11 @@ export class DatabaseApi extends RestApi {
    * Import a file at a specific path within the current database.
    */
   async importFile(ref: firebase.database.Reference, file: File) {
-    const params = new URLSearchParams({ ns: this.namespace });
+    const params = new URLSearchParams({
+      ns: this.namespace,
+      // Pass token in query since headers triggers CORS.
+      access_token: 'owner',
+    });
     const path = getUploadPath(ref) + `?${params.toString()}`;
     return await this.postFile(`${this.baseUrl}/${path}`, file);
   }

--- a/src/components/common/rest_api.ts
+++ b/src/components/common/rest_api.ts
@@ -68,7 +68,11 @@ export abstract class RestApi {
     const { accessToken } = await this.getToken();
     body.append('auth', accessToken);
 
-    // headers are NOT allowed or it breaks the multipart/form-data payload
+    // We cannot set the Content-Type header here, since that will
+    // break multipart/form-data payload.
+    // Furthermore, setting non-simple headers may cause a CORS pre-flight
+    // request. RTDB Emulator, for one, doesn't handle those correctly.
+    // See: https://fetch.spec.whatwg.org/#simple-header
     const res = await fetch(url, { method, body });
 
     const text = await res.text();


### PR DESCRIPTION
Headers don't work, let's use query strings.
https://firebase.google.com/docs/database/rest/auth#authenticate_with_an_access_token

I've also updated the comment to explain it in details.

Fixes #361. (tested locally)