### PR TITLE
Support != and not-in queries in Firestore viewer

### DIFF
--- a/src/components/Firestore/Collection.test.tsx
+++ b/src/components/Firestore/Collection.test.tsx
@@ -100,6 +100,29 @@ it('filters documents for single-value filters', async () => {
   expect(queryByText(/doc-without/)).toBeNull();
 });
 
+it('filters documents for single-value not operator filters', async () => {
+  useCollectionFilter.mockReturnValue({
+    field: 'foo',
+    operator: '!=',
+    value: 'bar',
+  });
+
+  const { getByText, queryByText } = await renderWithFirestore(
+    async firestore => {
+      const collectionRef = firestore.collection('my-stuff');
+      await collectionRef.doc('doc-with').set({ foo: 'not-bar' });
+      await collectionRef.doc('doc-without').set({ foo: 'bar' });
+
+      return <Collection collection={collectionRef} />;
+    }
+  );
+
+  await waitForElement(() => getByText(/doc-with/));
+
+  expect(getByText(/doc-with/)).not.toBeNull();
+  expect(queryByText(/doc-without/)).toBeNull();
+});
+
 it('filters documents for multi-value filters', async () => {
   useCollectionFilter.mockReturnValue({
     field: 'foo',
@@ -112,6 +135,30 @@ it('filters documents for multi-value filters', async () => {
       const collectionRef = firestore.collection('my-stuff');
       await collectionRef.doc('doc-with').set({ foo: 'eggs' });
       await collectionRef.doc('doc-without').set({ foo: 'not-eggs' });
+
+      return <Collection collection={collectionRef} />;
+    }
+  );
+
+  await waitForElement(() => getByText(/doc-with/));
+
+  expect(getByText(/doc-with/)).not.toBeNull();
+  expect(queryByText(/doc-without/)).toBeNull();
+});
+
+
+it('filters documents for multi-value not operator filters', async () => {
+  useCollectionFilter.mockReturnValue({
+    field: 'foo',
+    operator: 'not-in',
+    values: ['eggs', 'spam'],
+  });
+
+  const { getByText, queryByText } = await renderWithFirestore(
+    async firestore => {
+      const collectionRef = firestore.collection('my-stuff');
+      await collectionRef.doc('doc-with').set({ foo: 'not-eggs' });
+      await collectionRef.doc('doc-without').set({ foo: 'eggs' });
 
       return <Collection collection={collectionRef} />;
     }

--- a/src/components/Firestore/CollectionFilter/CollectionFilter.tsx
+++ b/src/components/Firestore/CollectionFilter/CollectionFilter.tsx
@@ -205,6 +205,10 @@ const ConditionSelect: React.FC = ({ children }) => {
       value: '==',
     },
     {
+      label: '(!=) not equal to',
+      value: '!=',
+    },
+    {
       label: '(>) greater than',
       value: '>',
     },
@@ -223,6 +227,10 @@ const ConditionSelect: React.FC = ({ children }) => {
     {
       label: '(in) equal to any of the following',
       value: 'in',
+    },
+    {
+      label: '(not-in) not equal to any of the following',
+      value: 'not-in',
     },
     {
       label: '(array-contains) an array containing',

--- a/src/components/Firestore/models.ts
+++ b/src/components/Firestore/models.ts
@@ -90,22 +90,26 @@ interface SortableCondition {
 
 type Unspecified = Filter<undefined> & SortableCondition;
 type Equal = Filter<'=='> & SingleValueCondition;
+type NotEqual = Filter<'!='> & SingleValueCondition;
 type GreaterThan = Filter<'>'> & SingleValueCondition & SortableCondition;
 type GreaterThanEqual = Filter<'>='> & SingleValueCondition & SortableCondition;
 type LessThanEqual = Filter<'<='> & SingleValueCondition & SortableCondition;
 type LessThan = Filter<'<'> & SingleValueCondition & SortableCondition;
 type In = Filter<'in'> & MultiValueCondition;
+type NotIn = Filter<'not-in'> & MultiValueCondition;
 type ArrayContains = Filter<'array-contains'> & SingleValueCondition;
 type ArrayContainsAny = Filter<'array-contains-any'> & MultiValueCondition;
 
 export type CollectionFilter =
   | Unspecified
   | Equal
+  | NotEqual
   | GreaterThan
   | GreaterThanEqual
   | LessThanEqual
   | LessThan
   | In
+  | NotIn
   | ArrayContains
   | ArrayContainsAny;
 
@@ -114,6 +118,7 @@ export function isSingleValueCollectionFilter(
 ): cf is Extract<CollectionFilter, SingleValueCondition> {
   return (
     cf.operator === '==' ||
+    cf.operator === '!=' ||
     cf.operator === '>' ||
     cf.operator === '>=' ||
     cf.operator === '<=' ||
@@ -125,7 +130,11 @@ export function isSingleValueCollectionFilter(
 export function isMultiValueCollectionFilter(
   cf: CollectionFilter
 ): cf is Extract<CollectionFilter, MultiValueCondition> {
-  return cf.operator === 'in' || cf.operator === 'array-contains-any';
+  return (
+    cf.operator === 'in' ||
+    cf.operator === 'not-in' ||
+    cf.operator === 'array-contains-any'
+  );
 }
 
 export function isSortableCollectionFilter(


### PR DESCRIPTION
This PR does != and not-in query supports in Firestore viewer. ( issue: https://github.com/firebase/firebase-tools-ui/issues/412 )

I updated the `firebase-js-sdk` version because it needs `WhereFilterOp` updates.
https://github.com/firebase/firebase-js-sdk/pull/3793