### PR TITLE
Remove unnecessary @firebase/testing dependency.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1897,9 +1897,9 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "@firebase/analytics": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.5.0.tgz",
-      "integrity": "sha512-WyQ8BT6JSoXpg4q7SV9Yg5EPXbGbG8FkkXAIhV/AnslCglhpxegO1FU33qbuT4Grzc525hZJA97oqtQS8tm4Wg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.0.tgz",
+      "integrity": "sha512-6qYEOPUVYrMhqvJ46Z5Uf1S4uULd6d7vGpMP5Qz+u8kIWuOQGcPdJKQap+Hla6Rq164or9gC2HRXuYXKlgWfpw==",
       "requires": {
         "@firebase/analytics-types": "0.4.0",
         "@firebase/component": "0.1.19",
@@ -1909,23 +1909,17 @@
         "tslib": "^1.11.1"
       },
       "dependencies": {
-        "@firebase/analytics-types": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.4.0.tgz",
-          "integrity": "sha512-Jj2xW+8+8XPfWGkv9HPv/uR+Qrmq37NPYT352wf7MvE9LrstpLVmFg3LqG6MCRr5miLAom5sen2gZ+iOhVDeRA=="
-        },
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@firebase/analytics-types": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.3.1.tgz",
-      "integrity": "sha512-63vVJ5NIBh/JF8l9LuPrQYSzFimk7zYHySQB4Dk9rVdJ8kV/vGQoVTvRu1UW05sEc2Ug5PqtEChtTHU+9hvPcA==",
-      "dev": true
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.4.0.tgz",
+      "integrity": "sha512-Jj2xW+8+8XPfWGkv9HPv/uR+Qrmq37NPYT352wf7MvE9LrstpLVmFg3LqG6MCRr5miLAom5sen2gZ+iOhVDeRA=="
     },
     "@firebase/app": {
       "version": "0.6.11",
@@ -1942,9 +1936,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -1954,9 +1948,9 @@
       "integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg=="
     },
     "@firebase/auth": {
-      "version": "0.14.9",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.14.9.tgz",
-      "integrity": "sha512-PxYa2r5qUEdheXTvqROFrMstK8W4uPiP7NVfp+2Bec+AjY5PxZapCx/YFDLkU0D7YBI82H74PtZrzdJZw7TJ4w==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.15.0.tgz",
+      "integrity": "sha512-IFuzhxS+HtOQl7+SZ/Mhaghy/zTU7CENsJFWbC16tv2wfLZbayKF5jYGdAU3VFLehgC8KjlcIWd10akc3XivfQ==",
       "requires": {
         "@firebase/auth-types": "0.10.1"
       }
@@ -1988,9 +1982,9 @@
       }
     },
     "@firebase/database": {
-      "version": "0.6.12",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.6.12.tgz",
-      "integrity": "sha512-OLUxp8TkXiML4X5LWM5IACsSDvo3fcf4mTbTe5RF+N6TRFv0Svzlet5OgGIa3ET1dQvNiisrMX7zzRa0OTLs7Q==",
+      "version": "0.6.13",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.6.13.tgz",
+      "integrity": "sha512-NommVkAPzU7CKd1gyehmi3lz0K78q0KOfiex7Nfy7MBMwknLm7oNqKovXSgQV1PCLvKXvvAplDSFhDhzIf9obA==",
       "requires": {
         "@firebase/auth-interop-types": "0.1.5",
         "@firebase/component": "0.1.19",
@@ -2002,9 +1996,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -2017,60 +2011,49 @@
       }
     },
     "@firebase/firestore": {
-      "version": "1.16.7",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.16.7.tgz",
-      "integrity": "sha512-MrX7te1eUib2pUzD3dLWdRuM7EPcCxtPwO4M9og3IFYr1U3XlxybD7kxyYswltHcUm6+kba3VKL1rvkqZ1sn2g==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.18.0.tgz",
+      "integrity": "sha512-maMq4ltkrwjDRusR2nt0qS4wldHQMp+0IDSfXIjC+SNmjnWY/t/+Skn9U3Po+dB38xpz3i7nsKbs+8utpDnPSw==",
       "requires": {
         "@firebase/component": "0.1.19",
-        "@firebase/firestore-types": "1.12.1",
+        "@firebase/firestore-types": "1.14.0",
         "@firebase/logger": "0.2.6",
         "@firebase/util": "0.3.2",
-        "@firebase/webchannel-wrapper": "0.3.0",
+        "@firebase/webchannel-wrapper": "0.4.0",
         "@grpc/grpc-js": "^1.0.0",
         "@grpc/proto-loader": "^0.5.0",
-        "node-fetch": "2.6.0",
+        "node-fetch": "2.6.1",
         "tslib": "^1.11.1"
       },
       "dependencies": {
-        "@firebase/firestore-types": {
-          "version": "1.12.1",
-          "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.12.1.tgz",
-          "integrity": "sha512-CpWcDriYnGDoAl0D9DcSuwX0b/fXqi7qOwuuTI1M0SYxau48G8cqhVjzjqPDgEM3kDGYJTnPN3ALS0Z4cnwERQ=="
-        },
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
-        },
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@firebase/firestore-types": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.12.0.tgz",
-      "integrity": "sha512-OqNxVb63wPZdUc7YnpacAW1WNIMSKERSewCRi+unCQ0YI0KNfrDSypyGCyel+S3GdOtKMk9KnvDknaGbnaFX4g==",
-      "dev": true
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.14.0.tgz",
+      "integrity": "sha512-WF8IBwHzZDhwyOgQnmB0pheVrLNP78A8PGxk1nxb/Nrgh1amo4/zYvFMGgSsTeaQK37xMYS/g7eS948te/dJxw=="
     },
     "@firebase/functions": {
-      "version": "0.4.51",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.4.51.tgz",
-      "integrity": "sha512-PPx8eZcr4eoU9BITOUGUVurs4WZu8Thj3uCWx766dU3mV1W/7kRgtiptmW0XJUB18FZ1PT3+Hadd6V6vjtLgYw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.5.1.tgz",
+      "integrity": "sha512-yyjPZXXvzFPjkGRSqFVS5Hc2Y7Y48GyyMH+M3i7hLGe69r/59w6wzgXKqTiSYmyE1pxfjxU4a1YqBDHNkQkrYQ==",
       "requires": {
         "@firebase/component": "0.1.19",
         "@firebase/functions-types": "0.3.17",
         "@firebase/messaging-types": "0.5.0",
-        "isomorphic-fetch": "2.2.1",
+        "node-fetch": "2.6.1",
         "tslib": "^1.11.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -2092,9 +2075,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -2122,9 +2105,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -2134,9 +2117,9 @@
       "integrity": "sha512-QaaBswrU6umJYb/ZYvjR5JDSslCGOH6D9P136PhabFAHLTR4TWjsaACvbBXuvwrfCXu10DtcjMxqfhdNIB1Xfg=="
     },
     "@firebase/performance": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.1.tgz",
-      "integrity": "sha512-eAqS3/456xnUwuTg4w58x2fYbvTtQpgt67lpBUX3DuhOqwiM8+JELRte52nDgum2lTaTZWiu5de9mPuAYx2WDg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.2.tgz",
+      "integrity": "sha512-irHTCVWJ/sxJo0QHg+yQifBeVu8ZJPihiTqYzBUz/0AGc51YSt49FZwqSfknvCN2+OfHaazz/ARVBn87g7Ex8g==",
       "requires": {
         "@firebase/component": "0.1.19",
         "@firebase/installations": "0.4.17",
@@ -2147,9 +2130,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -2168,11 +2151,6 @@
         "whatwg-fetch": "2.0.4"
       },
       "dependencies": {
-        "core-js": {
-          "version": "3.6.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
-        },
         "whatwg-fetch": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
@@ -2194,9 +2172,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -2217,9 +2195,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -2227,235 +2205,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.3.13.tgz",
       "integrity": "sha512-pL7b8d5kMNCCL0w9hF7pr16POyKkb3imOW7w0qYrhBnbyJTdVxMWZhb0HxCFyQWC0w3EiIFFmxoz8NTFZDEFog=="
-    },
-    "@firebase/testing": {
-      "version": "0.20.11",
-      "resolved": "https://registry.npmjs.org/@firebase/testing/-/testing-0.20.11.tgz",
-      "integrity": "sha512-cXu3B4NDG1HbmZby/lxaY7zAWdrhX/HzTzTkk15d3IJ0v+JlBHBWE8y8969UquoGv6fVcbTstUqMX3jgCRcfuw==",
-      "dev": true,
-      "requires": {
-        "@firebase/logger": "0.2.6",
-        "@firebase/util": "0.3.1",
-        "firebase": "7.18.0",
-        "request": "2.88.2"
-      },
-      "dependencies": {
-        "@firebase/analytics": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.4.2.tgz",
-          "integrity": "sha512-WCoeUAO3lP6ikHJ3/XYptV90fpTidzTS9VpAfiVQK8gl9w1zvvKSavY9U3+EVG3frOPCFdE5DBO4MYrUw4gaqw==",
-          "dev": true,
-          "requires": {
-            "@firebase/analytics-types": "0.3.1",
-            "@firebase/component": "0.1.18",
-            "@firebase/installations": "0.4.16",
-            "@firebase/logger": "0.2.6",
-            "@firebase/util": "0.3.1",
-            "tslib": "^1.11.1"
-          }
-        },
-        "@firebase/app": {
-          "version": "0.6.10",
-          "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.10.tgz",
-          "integrity": "sha512-USg/AbgqBERhY0LayrKmmp7pka08WPa7OlFI46kaNW1pA2mUNf/ifTaxhCr2hGg/eWI0zPhpbEvtGQhSJ/QqWg==",
-          "dev": true,
-          "requires": {
-            "@firebase/app-types": "0.6.1",
-            "@firebase/component": "0.1.18",
-            "@firebase/logger": "0.2.6",
-            "@firebase/util": "0.3.1",
-            "dom-storage": "2.1.0",
-            "tslib": "^1.11.1",
-            "xmlhttprequest": "1.8.0"
-          }
-        },
-        "@firebase/component": {
-          "version": "0.1.18",
-          "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.18.tgz",
-          "integrity": "sha512-c8gd1k/e0sbBTR0xkLIYUN8nVkA0zWxcXGIvdfYtGEsNw6n7kh5HkcxKXOPB8S7bcPpqZkGgBIfvd94IyG2gaQ==",
-          "dev": true,
-          "requires": {
-            "@firebase/util": "0.3.1",
-            "tslib": "^1.11.1"
-          }
-        },
-        "@firebase/database": {
-          "version": "0.6.11",
-          "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.6.11.tgz",
-          "integrity": "sha512-QOHhB7+CdjVhEXG9CyX0roA9ARJcEuwbozz0Bix+ULuZqjQ58KUFHMH1apW6EEiUP22d/mYD7dNXsUGshjL9PA==",
-          "dev": true,
-          "requires": {
-            "@firebase/auth-interop-types": "0.1.5",
-            "@firebase/component": "0.1.18",
-            "@firebase/database-types": "0.5.2",
-            "@firebase/logger": "0.2.6",
-            "@firebase/util": "0.3.1",
-            "faye-websocket": "0.11.3",
-            "tslib": "^1.11.1"
-          }
-        },
-        "@firebase/database-types": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.5.2.tgz",
-          "integrity": "sha512-ap2WQOS3LKmGuVFKUghFft7RxXTyZTDr0Xd8y2aqmWsbJVjgozi0huL/EUMgTjGFrATAjcf2A7aNs8AKKZ2a8g==",
-          "dev": true,
-          "requires": {
-            "@firebase/app-types": "0.6.1"
-          }
-        },
-        "@firebase/firestore": {
-          "version": "1.16.4",
-          "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.16.4.tgz",
-          "integrity": "sha512-Ur+I8a8RkkbbJRsebkYAUwKFkbh9FemDxTFD/2Vp01pAPM8S3MoIcVegAfTvnPlG/ObBq5O7wI4CRA6b/G/Iyg==",
-          "dev": true,
-          "requires": {
-            "@firebase/component": "0.1.18",
-            "@firebase/firestore-types": "1.12.0",
-            "@firebase/logger": "0.2.6",
-            "@firebase/util": "0.3.1",
-            "@firebase/webchannel-wrapper": "0.3.0",
-            "@grpc/grpc-js": "^1.0.0",
-            "@grpc/proto-loader": "^0.5.0",
-            "node-fetch": "2.6.0",
-            "tslib": "^1.11.1"
-          }
-        },
-        "@firebase/functions": {
-          "version": "0.4.50",
-          "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.4.50.tgz",
-          "integrity": "sha512-eBsNrUm/Jfc/xsQXmxQRSkEg6pwHlMd2hice8N90/EeqgwqS/SCvC+O9cJITLlXroAghb9jWDWRvAkDU/TOhpw==",
-          "dev": true,
-          "requires": {
-            "@firebase/component": "0.1.18",
-            "@firebase/functions-types": "0.3.17",
-            "@firebase/messaging-types": "0.5.0",
-            "isomorphic-fetch": "2.2.1",
-            "tslib": "^1.11.1"
-          }
-        },
-        "@firebase/installations": {
-          "version": "0.4.16",
-          "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.16.tgz",
-          "integrity": "sha512-gqv3IrBUmPWKpH8wLJ0fZcAH1NEXwQhqjqnK3cQXRcIkEARP430cmIAaj7CcPdgdemHX9HqwJG+So/yBHIYXPA==",
-          "dev": true,
-          "requires": {
-            "@firebase/component": "0.1.18",
-            "@firebase/installations-types": "0.3.4",
-            "@firebase/util": "0.3.1",
-            "idb": "3.0.2",
-            "tslib": "^1.11.1"
-          }
-        },
-        "@firebase/messaging": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.0.tgz",
-          "integrity": "sha512-PTD5pQw9QremOjiWWZYOkzcX6OKByMvlG+NQXdTnyL3kLbE01Bdp9iWhkH6ipNpHYMiwcK1RZD4TLkYVBviBsw==",
-          "dev": true,
-          "requires": {
-            "@firebase/component": "0.1.18",
-            "@firebase/installations": "0.4.16",
-            "@firebase/messaging-types": "0.5.0",
-            "@firebase/util": "0.3.1",
-            "idb": "3.0.2",
-            "tslib": "^1.11.1"
-          }
-        },
-        "@firebase/messaging-types": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/@firebase/messaging-types/-/messaging-types-0.5.0.tgz",
-          "integrity": "sha512-QaaBswrU6umJYb/ZYvjR5JDSslCGOH6D9P136PhabFAHLTR4TWjsaACvbBXuvwrfCXu10DtcjMxqfhdNIB1Xfg==",
-          "dev": true
-        },
-        "@firebase/performance": {
-          "version": "0.3.11",
-          "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.3.11.tgz",
-          "integrity": "sha512-L00vBUa2zzoSSOq3StTN43fPxtJ+myF+t+2kP5bQGHN5WOmf22lIsuEjAy1FAscDjVjhL1k5rKMY332ZwEfblg==",
-          "dev": true,
-          "requires": {
-            "@firebase/component": "0.1.18",
-            "@firebase/installations": "0.4.16",
-            "@firebase/logger": "0.2.6",
-            "@firebase/performance-types": "0.0.13",
-            "@firebase/util": "0.3.1",
-            "tslib": "^1.11.1"
-          }
-        },
-        "@firebase/remote-config": {
-          "version": "0.1.27",
-          "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.27.tgz",
-          "integrity": "sha512-BGjmQomRKNf+yGJ/3/5Kw6zNLM5jY9oTVjLmYsQXf6U+HMgz6J2H6EVGc1bZW7YSsvak8f6DomxegQtvfvwaMw==",
-          "dev": true,
-          "requires": {
-            "@firebase/component": "0.1.18",
-            "@firebase/installations": "0.4.16",
-            "@firebase/logger": "0.2.6",
-            "@firebase/remote-config-types": "0.1.9",
-            "@firebase/util": "0.3.1",
-            "tslib": "^1.11.1"
-          }
-        },
-        "@firebase/storage": {
-          "version": "0.3.42",
-          "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.42.tgz",
-          "integrity": "sha512-FqHDWZPhATQeOFBQUZPsQO7xhnGBxprYVDb9eIjCnh1yRl6WAv/OQGHOF+JU5+H+YkjsKTtr/5VjyDl3Y0UHxw==",
-          "dev": true,
-          "requires": {
-            "@firebase/component": "0.1.18",
-            "@firebase/storage-types": "0.3.13",
-            "@firebase/util": "0.3.1",
-            "tslib": "^1.11.1"
-          }
-        },
-        "@firebase/util": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.1.tgz",
-          "integrity": "sha512-zjVd9rfL08dRRdZILFn1RZTHb1euCcnD9N/9P56gdBcm2bvT5XsCC4G6t5toQBpE/H/jYe5h6MZMqfLu3EQLXw==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.11.1"
-          }
-        },
-        "@firebase/webchannel-wrapper": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.3.0.tgz",
-          "integrity": "sha512-VniCGPIgSGNEgOkh5phb3iKmSGIzcwrccy3IomMFRWPCMiCk2y98UQNJEoDs1yIHtZMstVjYWKYxnunIGzC5UQ==",
-          "dev": true
-        },
-        "firebase": {
-          "version": "7.18.0",
-          "resolved": "https://registry.npmjs.org/firebase/-/firebase-7.18.0.tgz",
-          "integrity": "sha512-RGq0rWX25EDsM21TjRe1FbnygJwHXL7yN4P0Zh2Z7dWrBcfJ8tQpDxgwMDtiJTuo9UYExK3py4wjgpGJBau6wg==",
-          "dev": true,
-          "requires": {
-            "@firebase/analytics": "0.4.2",
-            "@firebase/app": "0.6.10",
-            "@firebase/app-types": "0.6.1",
-            "@firebase/auth": "0.14.9",
-            "@firebase/database": "0.6.11",
-            "@firebase/firestore": "1.16.4",
-            "@firebase/functions": "0.4.50",
-            "@firebase/installations": "0.4.16",
-            "@firebase/messaging": "0.7.0",
-            "@firebase/performance": "0.3.11",
-            "@firebase/polyfill": "0.3.36",
-            "@firebase/remote-config": "0.1.27",
-            "@firebase/storage": "0.3.42",
-            "@firebase/util": "0.3.1"
-          }
-        },
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-          "dev": true
-        },
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
-          "dev": true
-        }
-      }
     },
     "@firebase/util": {
       "version": "0.3.2",
@@ -2473,18 +2222,25 @@
       }
     },
     "@firebase/webchannel-wrapper": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.3.0.tgz",
-      "integrity": "sha512-VniCGPIgSGNEgOkh5phb3iKmSGIzcwrccy3IomMFRWPCMiCk2y98UQNJEoDs1yIHtZMstVjYWKYxnunIGzC5UQ=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.4.0.tgz",
+      "integrity": "sha512-8cUA/mg0S+BxIZ72TdZRsXKBP5n5uRcE3k29TZhZw6oIiHBt9JA7CTb/4pE1uKtE/q5NeTY2tBDcagoZ+1zjXQ=="
     },
     "@grpc/grpc-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.1.3.tgz",
-      "integrity": "sha512-HtOsk2YUofBcm1GkPqGzb6pwHhv+74eC2CUO229USIDKRtg30ycbZmqC+HdNtY3nHqoc9IgcRlntFgopyQoYCA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.0.tgz",
+      "integrity": "sha512-09H50V7rmz0gFrGz6IbP49z9A8+2p4yZYcNDEb7bytr90vWn52VBQE1a+LMBlrucmNN0wSsiCr3TJx+dStHTng==",
       "requires": {
+        "@types/node": "^12.12.47",
+        "google-auth-library": "^6.1.1",
         "semver": "^6.2.0"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "12.19.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.4.tgz",
+          "integrity": "sha512-o3oj1bETk8kBwzz1WlO6JWL/AfAA3Vm6J1B3C9CsdxHYp7XgPiH7OEXPUbZTndHlRaIElrANkQfe6ZmfJb3H2w=="
+        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -5294,6 +5050,14 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.4.tgz",
       "integrity": "sha512-Eu9ELJWCz/c1e9gTiCY+FceWxcqzjYEbqMgtndnuSqZSUCOL73TWNK2mHfIj4Cw2E/ongOp+JISVNCmovt2KYQ=="
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -5387,6 +5151,14 @@
             "json5": "^1.0.1"
           }
         }
+      }
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
       }
     },
     "aggregate-error": {
@@ -6468,6 +6240,11 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
+    "bignumber.js": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+    },
     "binary-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
@@ -6725,6 +6502,11 @@
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         }
       }
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -8175,6 +7957,14 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -8226,24 +8016,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
-    },
-    "encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "requires": {
-        "iconv-lite": "^0.6.2"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
-          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        }
-      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -8932,6 +8704,11 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
     "eventemitter3": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.6.tgz",
@@ -9259,6 +9036,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
+    "fast-text-encoding": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
+      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
+    },
     "fastq": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.1.tgz",
@@ -9574,20 +9356,20 @@
       }
     },
     "firebase": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-7.20.0.tgz",
-      "integrity": "sha512-ijgiUPB93UGWw2P2kgUQgghu5WOn/WR2J8C/V6ZSeI1PQqiEwsfn0kvw4iMJeqLQpA/FVeZz/+p0ubE5kzqhBA==",
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-7.24.0.tgz",
+      "integrity": "sha512-j6jIyGFFBlwWAmrlUg9HyQ/x+YpsPkc/TTkbTyeLwwAJrpAmmEHNPT6O9xtAnMV4g7d3RqLL/u9//aZlbY4rQA==",
       "requires": {
-        "@firebase/analytics": "0.5.0",
+        "@firebase/analytics": "0.6.0",
         "@firebase/app": "0.6.11",
         "@firebase/app-types": "0.6.1",
-        "@firebase/auth": "0.14.9",
-        "@firebase/database": "0.6.12",
-        "@firebase/firestore": "1.16.7",
-        "@firebase/functions": "0.4.51",
+        "@firebase/auth": "0.15.0",
+        "@firebase/database": "0.6.13",
+        "@firebase/firestore": "1.18.0",
+        "@firebase/functions": "0.5.1",
         "@firebase/installations": "0.4.17",
         "@firebase/messaging": "0.7.1",
-        "@firebase/performance": "0.4.1",
+        "@firebase/performance": "0.4.2",
         "@firebase/polyfill": "0.3.36",
         "@firebase/remote-config": "0.1.28",
         "@firebase/storage": "0.3.43",
@@ -9879,6 +9661,34 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
+    "gaxios": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.0.1.tgz",
+      "integrity": "sha512-jOin8xRZ/UytQeBpSXFqIzqU7Fi5TqgPNLlUsSB8kjJ76+FiGBfImF8KJu++c6J4jOldfJUtt0YmkRj2ZpSHTQ==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.3.0"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        }
+      }
+    },
+    "gcp-metadata": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.2.1.tgz",
+      "integrity": "sha512-tSk+REe5iq/N+K+SK1XjZJUrFPuDqGZVzCy2vocIHIGmPlTGsa8owXMJwGkrXr73NO0AzhPW4MF2DEHz7P2AVw==",
+      "requires": {
+        "gaxios": "^4.0.0",
+        "json-bigint": "^1.0.0"
+      }
+    },
     "gensync": {
       "version": "1.0.0-beta.1",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
@@ -10002,6 +9812,52 @@
         "slash": "^3.0.0"
       }
     },
+    "google-auth-library": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.3.tgz",
+      "integrity": "sha512-m9mwvY3GWbr7ZYEbl61isWmk+fvTmOt0YNUfPOUY2VH8K5pZlAIWJjxEi0PqR3OjMretyiQLI6GURMrPSwHQ2g==",
+      "requires": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^4.0.0",
+        "gcp-metadata": "^4.2.0",
+        "gtoken": "^5.0.4",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "arrify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        }
+      }
+    },
+    "google-p12-pem": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.3.tgz",
+      "integrity": "sha512-wS0ek4ZtFx/ACKYF3JhyGe5kzH7pgiQ7J5otlumqR9psmWMYc+U9cErKlCYVYHoUaidXHdZ2xbo34kB+S+24hA==",
+      "requires": {
+        "node-forge": "^0.10.0"
+      },
+      "dependencies": {
+        "node-forge": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+          "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+        }
+      }
+    },
     "graceful-fs": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
@@ -10011,6 +9867,24 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+    },
+    "gtoken": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.5.tgz",
+      "integrity": "sha512-wvjkecutFh8kVfbcdBdUWqDRrXb+WrgD79DBDEYf1Om8S1FluhylhtFjrL7Tx69vNhh259qA3Q1P4sPtb+kUYw==",
+      "requires": {
+        "gaxios": "^4.0.0",
+        "google-p12-pem": "^3.0.3",
+        "jws": "^4.0.0",
+        "mime": "^2.2.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+        }
+      }
     },
     "gzip-size": {
       "version": "5.1.1",
@@ -10506,6 +10380,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
     },
     "husky": {
       "version": "3.1.0",
@@ -11248,26 +11131,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
-        }
-      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -12392,6 +12255,14 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
+    "json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "requires": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -12474,6 +12345,25 @@
       "requires": {
         "array-includes": "^3.1.1",
         "object.assign": "^4.1.0"
+      }
+    },
+    "jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "requires": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "keycode": {
@@ -15288,9 +15178,9 @@
       }
     },
     "protobufjs": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.1.tgz",
-      "integrity": "sha512-pb8kTchL+1Ceg4lFd5XUpK8PdWacbvV5SK2ULH2ebrYtl4GjJmS24m6CKME67jzV53tbJxHlnNOSqQHbTsR9JQ==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.2.tgz",
+      "integrity": "sha512-27yj+04uF6ya9l+qfpH187aqEzfCF4+Uit0I9ZBQVqK09hk/SQzKa2MUqUpXaVa7LOFRg1TSSr3lVxGOk6c0SQ==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/recompose": "^0.30.7",
     "classnames": "^2.2.6",
     "express": "^4.17.1",
-    "firebase": "^7.17.1",
+    "firebase": "^7.24.0",
     "font-awesome": "^4.7.0",
     "immer": "^7.0.0",
     "keycode": "^2.2.0",
@@ -99,7 +99,6 @@
   "devDependencies": {
     "@firebase/auth-interop-types": "^0.1.4",
     "@firebase/component": "^0.1.8",
-    "@firebase/testing": "^0.20.11",
     "@testing-library/react": "^9.5.0",
     "@types/classnames": "^2.2.10",
     "@types/lodash.get": "^4.4.6",

--- a/src/components/Firestore/FirestoreEmulatedApiProvider.tsx
+++ b/src/components/Firestore/FirestoreEmulatedApiProvider.tsx
@@ -32,7 +32,9 @@ interface WindowWithFirestore extends Window {
  * Provide a local-FirebaseApp with a FirestoreSDK connected to
  * the Emulator Hub.
  */
-export const FirestoreEmulatedApiProvider: React.FC = React.memo(props => {
+export const FirestoreEmulatedApiProvider: React.FC<{
+  disableDevTools?: boolean;
+}> = React.memo(({ children, disableDevTools }) => {
   const config = useFirestoreConfig();
   const app = useEmulatedFirebaseApp('firestore', config);
 
@@ -41,8 +43,8 @@ export const FirestoreEmulatedApiProvider: React.FC = React.memo(props => {
       <Suspense
         fallback={<Spinner message="Loading Firestore SDK" span={12} />}
       >
-        <FirestoreEmulatorSettings {...props} />
-        <FirestoreDevTools />
+        <FirestoreEmulatorSettings>{children}</FirestoreEmulatorSettings>
+        {disableDevTools || <FirestoreDevTools />}
       </Suspense>
     </FirebaseAppProvider>
   );


### PR DESCRIPTION
1. `@firebase/testing` is deprecated and it prevents us from upgrading `firebase` due to version pinning.
1. `@firebase/testing` is not required to connect to the emulators. Importing `firebase` in a Node.js environment gives you a functional Node.js client (not admin) library.
1. This PR also simplifies test setup and covers more real logic.