### PR TITLE
Add lexicographical order for fields in document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@
 .eslintcache
 settings.json
 
-*-debug.log*
+*debug.log*
 yarn-error.log*
 
 .idea

--- a/src/components/Firestore/DocumentPreview/FieldPreview.tsx
+++ b/src/components/Firestore/DocumentPreview/FieldPreview.tsx
@@ -27,6 +27,7 @@ import React, { useState } from 'react';
 import { supportsEditing } from '../DocumentEditor';
 import { FirestoreArray } from '../models';
 import {
+  compareFirestoreKeys,
   getFieldType,
   getParentPath,
   isArray,
@@ -54,17 +55,19 @@ const FieldPreview: React.FC<{
   let childFields = null;
   if (isMap(state)) {
     // Inline editor for new field will default to key: ''
-    childFields = Object.keys(state).map(childLeaf => {
-      const childPath = [...path, childLeaf];
-      return (
-        <FieldPreview
-          key={childLeaf}
-          path={childPath}
-          documentRef={documentRef}
-          maxSummaryLen={maxSummaryLen}
-        />
-      );
-    });
+    childFields = Object.keys(state)
+      .sort(compareFirestoreKeys)
+      .map(childLeaf => {
+        const childPath = [...path, childLeaf];
+        return (
+          <FieldPreview
+            key={childLeaf}
+            path={childPath}
+            documentRef={documentRef}
+            maxSummaryLen={maxSummaryLen}
+          />
+        );
+      });
   } else if (isArray(state)) {
     // Inline editor for new field will default to key: '{index}'
     childFields = state.map((value, index) => {

--- a/src/components/Firestore/DocumentPreview/index.test.tsx
+++ b/src/components/Firestore/DocumentPreview/index.test.tsx
@@ -279,8 +279,8 @@ describe('loaded map', () => {
       documentReference.update = jest.fn();
       await documentReference.set({
         foo: {
-          first_name: 'harry',
           last_name: 'potter',
+          first_name: 'harry',
         },
       });
       return (
@@ -291,10 +291,10 @@ describe('loaded map', () => {
     await waitForElement(() => result.getAllByText(/harry/).length > 0);
   });
 
-  it('renders a field', () => {
+  it('renders a field, in the lexicographical order', () => {
     const { getByText } = result;
 
-    expect(getByText('{last_name: "potter", first_name: "harry"}')).not.toBe(
+    expect(getByText('{first_name: "harry", last_name: "potter"}')).not.toBe(
       null
     );
     expect(getByText('(map)')).not.toBe(null);
@@ -306,7 +306,7 @@ describe('loaded map', () => {
     expect(getByText('first_name')).not.toBe(null);
     expect(getByText('last_name')).not.toBe(null);
 
-    getByText('{last_name: "potter", first_name: "harry"}').click();
+    getByText('{first_name: "harry", last_name: "potter"}').click();
 
     expect(queryByText('first_name')).toBe(null);
     expect(queryByText('last_name')).toBe(null);
@@ -325,7 +325,7 @@ describe('loaded map', () => {
 
     await act(async () => {
       // Edit first-name
-      queryAllByText('edit')[1].click();
+      queryAllByText('edit')[0].click();
     });
     await act(async () => {
       fireEvent.change(getByLabelText('Value'), {

--- a/src/components/Firestore/DocumentPreview/index.tsx
+++ b/src/components/Firestore/DocumentPreview/index.tsx
@@ -21,7 +21,7 @@ import firebase from 'firebase';
 import React, { useState } from 'react';
 import { useFirestoreDocData } from 'reactfire';
 
-import { isMap } from '../utils';
+import { compareFirestoreKeys, isMap } from '../utils';
 import { addFieldToMissingDocument, updateField } from './api';
 import FieldPreview from './FieldPreview';
 import InlineEditor from './InlineEditor';
@@ -78,14 +78,16 @@ const DocumentPreview: React.FC<Props> = ({
 
           {docExists && isMap(data) ? (
             <div className="Firestore-Field-List">
-              {Object.keys(data).map(name => (
-                <FieldPreview
-                  key={name}
-                  path={[name]}
-                  documentRef={reference}
-                  maxSummaryLen={maxSummaryLen}
-                />
-              ))}
+              {Object.keys(data)
+                .sort(compareFirestoreKeys)
+                .map(name => (
+                  <FieldPreview
+                    key={name}
+                    path={[name]}
+                    documentRef={reference}
+                    maxSummaryLen={maxSummaryLen}
+                  />
+                ))}
             </div>
           ) : (
             <Typography

--- a/src/components/Firestore/utils.ts
+++ b/src/components/Firestore/utils.ts
@@ -194,7 +194,9 @@ function summarizeMap(
   maxLen: number
 ): string {
   let output = '{';
-  for (const [key, value] of Object.entries(map)) {
+  for (const [key, value] of Object.entries(map).sort((a, b) =>
+    compareFirestoreKeys(a[0], b[0])
+  )) {
     if (output.length > 1) output += ', ';
     if (output.length > maxLen) {
       output += '...';
@@ -212,4 +214,9 @@ function latStr(lat: number): string {
 
 function longStr(long: number): string {
   return `${Math.abs(long)}° ${long >= 0 ? 'E' : 'W'}`;
+}
+
+export function compareFirestoreKeys(fieldA: string, fieldB: string): number {
+  // TODO: Use UTF-8 encoded byte order instead of localCompare to match Firestore production behavior https://firebase.google.com/docs/firestore/manage-data/data-types
+  return fieldA.localeCompare(fieldB);
 }


### PR DESCRIPTION
This PR adds the lexicographical ordering for the fields in a document on the UI. I didn't touch the files related to collections and subcollections since I noticed they were already ordered.

I also adapted the tests to the new ordering. Do I need to add also a test that clearly checks for the ordering? If so, do you have any suggestions on how to check that an element comes after/before another one? Thank you!

The following images show the before and after, where in the after the order is always respected

### fields order
#### before
![befFields](https://user-images.githubusercontent.com/32385294/101402813-8a554b80-38d4-11eb-83ce-a2ba6cea9b9e.png)
#### after
![aftFields](https://user-images.githubusercontent.com/32385294/101402804-89241e80-38d4-11eb-9d5d-66ba84e3ed6e.png)
### map nested
#### before
![bef nested](https://user-images.githubusercontent.com/32385294/101402812-89bcb500-38d4-11eb-80fa-1a975f1399a8.png)
#### after
![aftNested](https://user-images.githubusercontent.com/32385294/101402805-89241e80-38d4-11eb-88c6-1bad25b4b649.png)
### map summary
#### before
![befSum](https://user-images.githubusercontent.com/32385294/101402803-888b8800-38d4-11eb-863b-edbe66999b1c.png)
#### after
![aftSum](https://user-images.githubusercontent.com/32385294/101402808-89bcb500-38d4-11eb-93ef-a7c61b5b9918.png)

Fixes #438