### PR TITLE
Firestore request evaluations global subscription

### DIFF
--- a/src/components/App/AppBar.test.tsx
+++ b/src/components/App/AppBar.test.tsx
@@ -20,12 +20,8 @@ import { act } from 'react-dom/test-utils';
 import { MemoryRouter } from 'react-router-dom';
 
 import { delay } from '../../test_utils';
+import { isTabActive } from '../../test_utils';
 import { AppBar } from './AppBar';
-
-function isTabActive(labelEl: HTMLElement) {
-  const tabEl = labelEl.closest('.mdc-tab')!;
-  return tabEl.classList.contains('mdc-tab--active');
-}
 
 it('selects the matching nav-tab', async () => {
   const { getByText } = render(

--- a/src/components/App/index.test.tsx
+++ b/src/components/App/index.test.tsx
@@ -15,16 +15,17 @@
  */
 
 import { render } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, Router } from 'react-router-dom';
 
 import configureStore from '../../configureStore';
 import { delay, waitForDialogsToOpen } from '../../test_utils';
 import { alert } from '../common/DialogQueue';
-import App from '.';
+import App, { REDIRECT_LOGS_URL } from '.';
 
 it('renders without crashing', async () => {
   const div = document.createElement('div');
@@ -63,4 +64,21 @@ it('shows dialogs in the queue', async () => {
   await waitForDialogsToOpen();
 
   expect(getByText('wowah')).not.toBeNull();
+});
+
+it('redirects from url /functions to correct logs url', async () => {
+  const store = configureStore();
+  const history = createMemoryHistory({
+    initialEntries: ['/functions'],
+  });
+  render(
+    <Provider store={store}>
+      <Router history={history}>
+        <App />
+      </Router>
+    </Provider>
+  );
+  await act(() => delay(100)); // Wait for tab indicator async DOM updates.
+  const { pathname, search } = history.location;
+  expect(pathname + search).toBe(REDIRECT_LOGS_URL);
 });

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -28,6 +28,9 @@ import { dialogs } from '../common/DialogQueue';
 import AppBar from './AppBar';
 import AppDisconnected from './AppDisconnected';
 
+export const REDIRECT_LOGS_URL =
+  '/logs?q=metadata.emulator.name%3D%22functions%22';
+
 const App: React.FC = () => {
   return (
     <>
@@ -39,7 +42,7 @@ const App: React.FC = () => {
           <AppBar routes={routes} />
           <Grid className="App-main">
             <Switch>
-              {routes.map(r => (
+              {routes.map((r) => (
                 <Route
                   key={r.path}
                   path={r.path}
@@ -47,10 +50,7 @@ const App: React.FC = () => {
                   exact={r.exact}
                 />
               ))}
-              <Redirect
-                from="/functions"
-                to="/logs?q=metadata.emulator.name%3D%22functions%22"
-              />
+              <Redirect from="/functions" to={REDIRECT_LOGS_URL} />
               <Redirect to="/" /> {/* Fallback to redirect to overview. */}
             </Switch>
           </Grid>

--- a/src/components/Firestore/CollectionList.test.tsx
+++ b/src/components/Firestore/CollectionList.test.tsx
@@ -27,7 +27,7 @@ import {
 import { renderWithFirestore } from './testing/FirestoreTestProviders';
 
 it('shows the root-collection list', async () => {
-  const { getByText } = await renderWithFirestore(async firestore => {
+  const { getByText } = await renderWithFirestore(async (firestore) => {
     await firestore.doc('coll-1/thing').set({ a: 1 });
     await firestore.doc('coll-2/thing').set({ a: 1 });
     return <RootCollectionList />;
@@ -40,16 +40,10 @@ it('shows the root-collection list', async () => {
 });
 
 it('shows the sub-collection list', async () => {
-  const { getByText } = await renderWithFirestore(async firestore => {
+  const { getByText } = await renderWithFirestore(async (firestore) => {
     const docRef = firestore.doc('top/thing');
-    await docRef
-      .collection('coll-1')
-      .doc('other')
-      .set({ a: 1 });
-    await docRef
-      .collection('coll-2')
-      .doc('other')
-      .set({ a: 1 });
+    await docRef.collection('coll-1').doc('other').set({ a: 1 });
+    await docRef.collection('coll-2').doc('other').set({ a: 1 });
     return <SubCollectionList reference={docRef} />;
   });
 
@@ -60,10 +54,10 @@ it('shows the sub-collection list', async () => {
 });
 
 it('redirects to collection when clicking the collection list item', async () => {
-  const history = createMemoryHistory({ initialEntries: ['/firestore'] });
+  const history = createMemoryHistory({ initialEntries: ['/firestore/data'] });
   const { getByTestId } = await render(
     <Router history={history}>
-      <Route path="/firestore">
+      <Route path="/firestore/data">
         <CollectionListItem
           collectionId="sub-coll-1"
           routeMatchUrl="/coll-1/thing"
@@ -77,10 +71,10 @@ it('redirects to collection when clicking the collection list item', async () =>
 });
 
 it('redirects to collection when clicking the collection list item and the ids have special characters', async () => {
-  const history = createMemoryHistory({ initialEntries: ['/firestore'] });
+  const history = createMemoryHistory({ initialEntries: ['/firestore/data'] });
   const { getByTestId } = await render(
     <Router history={history}>
-      <Route path="/firestore">
+      <Route path="/firestore/data">
         <CollectionListItem
           collectionId="sub-coll-1@#$"
           routeMatchUrl="/coll-1%40%23%24/thing%40%23%24"
@@ -97,20 +91,20 @@ it('redirects to collection when clicking the collection list item and the ids h
 
 it('triggers a redirect to a new collection at the root', async () => {
   const { getByLabelText, getByText } = await renderWithFirestore(
-    async firestore => {
+    async (firestore) => {
       await firestore.doc('coll-1/thing').set({ a: 1 });
       return (
         <>
-          <Route path="/firestore/coll-1">
+          <Route path="/firestore/data/coll-1">
             <RootCollectionList />
           </Route>
 
-          <Route path="/firestore/abc">_redirected_to_foo_</Route>
+          <Route path="/firestore/data/abc">_redirected_to_foo_</Route>
         </>
       );
     },
     {
-      path: '/firestore/coll-1',
+      path: '/firestore/data/coll-1',
     }
   );
 
@@ -143,20 +137,20 @@ it('triggers a redirect to a new collection at the root', async () => {
 
 it('triggers a redirect to a new collection at the root when there are special characters on the ids', async () => {
   const { getByLabelText, getByText } = await renderWithFirestore(
-    async firestore => {
+    async (firestore) => {
       await firestore.doc('coll-1@#$/thing@#$').set({ a: 1 });
       return (
         <>
-          <Route path="/firestore/coll-1%40%23%24">
+          <Route path="/firestore/data/coll-1%40%23%24">
             <RootCollectionList />
           </Route>
 
-          <Route path="/firestore/abc%40%23%24">_redirected_to_foo_</Route>
+          <Route path="/firestore/data/abc%40%23%24">_redirected_to_foo_</Route>
         </>
       );
     },
     {
-      path: '/firestore/coll-1%40%23%24',
+      path: '/firestore/data/coll-1%40%23%24',
     }
   );
 
@@ -189,26 +183,23 @@ it('triggers a redirect to a new collection at the root when there are special c
 
 it('triggers a redirect to a new collection in a document', async () => {
   const { getByLabelText, getByText } = await renderWithFirestore(
-    async firestore => {
+    async (firestore) => {
       const docRef = firestore.doc('top/thing');
-      await docRef
-        .collection('coll-1')
-        .doc('other')
-        .set({ a: 1 });
+      await docRef.collection('coll-1').doc('other').set({ a: 1 });
       return (
         <>
-          <Route path="/firestore/top/thing">
+          <Route path="/firestore/data/top/thing">
             <SubCollectionList reference={docRef} />
           </Route>
 
-          <Route path="/firestore/top/thing/abc">
+          <Route path="/firestore/data/top/thing/abc">
             _redirected_to_sub_document_
           </Route>
         </>
       );
     },
     {
-      path: '/firestore/top/thing',
+      path: '/firestore/data/top/thing',
     }
   );
 
@@ -241,26 +232,23 @@ it('triggers a redirect to a new collection in a document', async () => {
 
 it('triggers a redirect to a new collection in a document when there are special characters on the ids', async () => {
   const { getByLabelText, getByText } = await renderWithFirestore(
-    async firestore => {
+    async (firestore) => {
       const docRef = firestore.doc('top@#$/thing@#$');
-      await docRef
-        .collection('coll-1@#$')
-        .doc('other@#$')
-        .set({ a: 1 });
+      await docRef.collection('coll-1@#$').doc('other@#$').set({ a: 1 });
       return (
         <>
-          <Route path="/firestore/top%40%23%24/thing%40%23%24">
+          <Route path="/firestore/data/top%40%23%24/thing%40%23%24">
             <SubCollectionList reference={docRef} />
           </Route>
 
-          <Route path="/firestore/top%40%23%24/thing%40%23%24/abc%40%23%24">
+          <Route path="/firestore/data/top%40%23%24/thing%40%23%24/abc%40%23%24">
             _redirected_to_sub_document_
           </Route>
         </>
       );
     },
     {
-      path: '/firestore/top%40%23%24/thing%40%23%24',
+      path: '/firestore/data/top%40%23%24/thing%40%23%24',
     }
   );
 

--- a/src/components/Firestore/CollectionList.tsx
+++ b/src/components/Firestore/CollectionList.tsx
@@ -71,13 +71,13 @@ const CollectionList: React.FC<Props> = ({ collections, reference }) => {
       if (reference) {
         const encodedReferencePath = reference.path
           .split('/')
-          .map(uri => encodeURIComponent(uri))
+          .map((uri) => encodeURIComponent(uri))
           .join('/');
         history.push(
-          `/firestore/${encodedReferencePath}/${encodedCollectionId}`
+          `/firestore/data/${encodedReferencePath}/${encodedCollectionId}`
         );
       } else {
-        history.push(`/firestore/${encodedCollectionId}`);
+        history.push(`/firestore/data/${encodedCollectionId}`);
       }
     }
   };
@@ -107,7 +107,7 @@ const CollectionList: React.FC<Props> = ({ collections, reference }) => {
 
       <List dense tag="div">
         {collections &&
-          collections.map(coll => (
+          collections.map((coll) => (
             <CollectionListItem
               key={coll.id}
               collectionId={coll.id}

--- a/src/components/Firestore/Document.test.tsx
+++ b/src/components/Firestore/Document.test.tsx
@@ -31,7 +31,7 @@ it('shows the root-id', async () => {
 });
 
 it('shows the document-id', async () => {
-  const { getByText } = await renderWithFirestore(async firestore => {
+  const { getByText } = await renderWithFirestore(async (firestore) => {
     const docRef = firestore.doc('my-stuff/foo');
     await docRef.set({ a: 1 });
     return (
@@ -49,7 +49,7 @@ it('shows the document-id', async () => {
 
 it('shows the root collection-list', async () => {
   const { getByText, getByTestId } = await renderWithFirestore(
-    async firestore => {
+    async (firestore) => {
       await firestore.doc('foo/bar').set({ a: 1 });
       return (
         <>
@@ -68,12 +68,9 @@ it('shows the root collection-list', async () => {
 
 it('shows the document collection-list', async () => {
   const { getByText, getByTestId } = await renderWithFirestore(
-    async firestore => {
+    async (firestore) => {
       const documentRef = firestore.doc('foo/bar');
-      await documentRef
-        .collection('sub')
-        .doc('spam')
-        .set({ a: 1 });
+      await documentRef.collection('sub').doc('spam').set({ a: 1 });
       return (
         <>
           <Document reference={documentRef} />
@@ -91,17 +88,17 @@ it('shows the document collection-list', async () => {
 
 it('shows the selected root-collection', async () => {
   const { getAllByText, getAllByTestId } = await renderWithFirestore(
-    async firestore => {
+    async (firestore) => {
       await firestore.doc('foo/bar').set({ a: 1 });
       return (
-        <Route path="/firestore">
+        <Route path="/firestore/data">
           <Root />
           <Portal />
         </Route>
       );
     },
     {
-      path: '/firestore/foo',
+      path: '/firestore/data/foo',
     }
   );
 
@@ -114,17 +111,17 @@ it('shows the selected root-collection', async () => {
 
 it('shows the selected root-collection when the collection id has special characters', async () => {
   const { getAllByText, getAllByTestId } = await renderWithFirestore(
-    async firestore => {
+    async (firestore) => {
       await firestore.doc('foo@#$/bar').set({ a: 1 });
       return (
-        <Route path="/firestore">
+        <Route path="/firestore/data">
           <Root />
           <Portal />
         </Route>
       );
     },
     {
-      path: '/firestore/foo%40%23%24',
+      path: '/firestore/data/foo%40%23%24',
     }
   );
 
@@ -137,21 +134,18 @@ it('shows the selected root-collection when the collection id has special charac
 
 it('shows the selected document-collection', async () => {
   const { getAllByTestId, getByText } = await renderWithFirestore(
-    async firestore => {
+    async (firestore) => {
       const documentRef = firestore.doc('foo/bar');
-      await documentRef
-        .collection('sub')
-        .doc('doc')
-        .set({ spam: 'eggs' });
+      await documentRef.collection('sub').doc('doc').set({ spam: 'eggs' });
       return (
-        <Route path="/firestore/foo/bar">
+        <Route path="/firestore/data/foo/bar">
           <Document reference={documentRef} />
           <Portal />
         </Route>
       );
     },
     {
-      path: '/firestore/foo/bar/sub/doc',
+      path: '/firestore/data/foo/bar/sub/doc',
     }
   );
 
@@ -163,21 +157,22 @@ it('shows the selected document-collection', async () => {
 
 it('shows the selected document-collection when there are collection and document ids with special characters', async () => {
   const { getAllByTestId, getByText } = await renderWithFirestore(
-    async firestore => {
+    async (firestore) => {
       const documentRef = firestore.doc('foo@#$/bar@#$');
       await documentRef
         .collection('sub@#$')
         .doc('doc@#$')
         .set({ spam: 'eggs' });
       return (
-        <Route path="/firestore/foo%40%23%24/bar%40%23%24">
+        <Route path="/firestore/data/foo%40%23%24/bar%40%23%24">
           <Document reference={documentRef} />
           <Portal />
         </Route>
       );
     },
     {
-      path: '/firestore/foo%40%23%24/bar%40%23%24/sub%40%23%24/doc%40%23%24',
+      path:
+        '/firestore/data/foo%40%23%24/bar%40%23%24/sub%40%23%24/doc%40%23%24',
     }
   );
 

--- a/src/components/Firestore/DocumentListItem.test.tsx
+++ b/src/components/Firestore/DocumentListItem.test.tsx
@@ -23,10 +23,12 @@ import DocumentListItem from './DocumentListItem';
 
 describe('DocumentListItem', () => {
   it('shows the query value when queryFieldValue is string', async () => {
-    const history = createMemoryHistory({ initialEntries: ['/firestore'] });
+    const history = createMemoryHistory({
+      initialEntries: ['/firestore/data'],
+    });
     const { queryByText, queryByTestId } = await render(
       <Router history={history}>
-        <Route path="/firestore">
+        <Route path="/firestore/data">
           <DocumentListItem
             docId="an-item"
             url="/my-stuff"
@@ -42,10 +44,12 @@ describe('DocumentListItem', () => {
   });
 
   it('shows the query value when queryFieldValue is number', async () => {
-    const history = createMemoryHistory({ initialEntries: ['/firestore'] });
+    const history = createMemoryHistory({
+      initialEntries: ['/firestore/data'],
+    });
     const { queryByText, queryByTestId } = await render(
       <Router history={history}>
-        <Route path="/firestore">
+        <Route path="/firestore/data">
           <DocumentListItem
             docId="an-item"
             url="/my-stuff"
@@ -61,10 +65,12 @@ describe('DocumentListItem', () => {
   });
 
   it('shows the query value when queryFieldValue is boolean', async () => {
-    const history = createMemoryHistory({ initialEntries: ['/firestore'] });
+    const history = createMemoryHistory({
+      initialEntries: ['/firestore/data'],
+    });
     const { queryByText, queryByTestId } = await render(
       <Router history={history}>
-        <Route path="/firestore">
+        <Route path="/firestore/data">
           <DocumentListItem
             docId="an-item"
             url="/my-stuff"
@@ -80,10 +86,12 @@ describe('DocumentListItem', () => {
   });
 
   it('shows the query value when queryFieldValue is null', async () => {
-    const history = createMemoryHistory({ initialEntries: ['/firestore'] });
+    const history = createMemoryHistory({
+      initialEntries: ['/firestore/data'],
+    });
     const { queryByText, queryByTestId } = await render(
       <Router history={history}>
-        <Route path="/firestore">
+        <Route path="/firestore/data">
           <DocumentListItem
             docId="an-item"
             url="/my-stuff"
@@ -99,10 +107,12 @@ describe('DocumentListItem', () => {
   });
 
   it('does not show the query value when queryFieldValue is undefined', async () => {
-    const history = createMemoryHistory({ initialEntries: ['/firestore'] });
+    const history = createMemoryHistory({
+      initialEntries: ['/firestore/data'],
+    });
     const { debug, queryByText, queryByTestId } = await render(
       <Router history={history}>
-        <Route path="/firestore">
+        <Route path="/firestore/data">
           <DocumentListItem
             docId="an-item"
             url="/my-stuff"
@@ -117,10 +127,12 @@ describe('DocumentListItem', () => {
   });
 
   it('redirects to document path when clicking the document list item', async () => {
-    const history = createMemoryHistory({ initialEntries: ['/firestore'] });
+    const history = createMemoryHistory({
+      initialEntries: ['/firestore/data'],
+    });
     const { getByTestId } = await render(
       <Router history={history}>
-        <Route path="/firestore">
+        <Route path="/firestore/data">
           <DocumentListItem
             docId="an-item"
             url="/my-stuff"
@@ -135,10 +147,12 @@ describe('DocumentListItem', () => {
   });
 
   it('redirects to document path when clicking the document list item and the document id has special characters', async () => {
-    const history = createMemoryHistory({ initialEntries: ['/firestore'] });
+    const history = createMemoryHistory({
+      initialEntries: ['/firestore/data'],
+    });
     const { getByTestId } = await render(
       <Router history={history}>
-        <Route path="/firestore">
+        <Route path="/firestore/data">
           <DocumentListItem
             docId="an-item@#$"
             url="/my-stuff"

--- a/src/components/Firestore/Requests/RequestDetails/index.tsx
+++ b/src/components/Firestore/Requests/RequestDetails/index.tsx
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+export interface PropsFromParentComponent {
+  requestId?: string;
+}
+export interface Props extends PropsFromParentComponent {}
+
+const RequestDetails: React.FC<Props> = ({ requestId }) => (
+  <div data-testid="request-details">
+    <div>Request Details Header</div>
+    <div>Request Details Code Viewer</div>
+    <div>Request Details Inspection Section</div>
+  </div>
+);
+
+export default RequestDetails;

--- a/src/components/Firestore/Requests/RequestsCard/index.tsx
+++ b/src/components/Firestore/Requests/RequestsCard/index.tsx
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+const RequestsCard: React.FC = () => (
+  <div data-testid="requests-card">
+    <div>Requests Header</div>
+    <div>Requests Table</div>
+  </div>
+);
+
+export default RequestsCard;

--- a/src/components/Firestore/Requests/index.test.tsx
+++ b/src/components/Firestore/Requests/index.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import FirestoreRequests from '.';
+
+describe('Firestore Requests', () => {
+  it('renders requests table when /firestore/requests', async () => {
+    const { getByTestId } = render(
+      <MemoryRouter initialEntries={['/firestore/requests']}>
+        <FirestoreRequests />
+      </MemoryRouter>
+    );
+
+    expect(getByTestId('requests-card')).not.toBeNull();
+  });
+
+  it('renders request details view when /firestore/requests/:requestId', async () => {
+    const { getByTestId } = render(
+      <MemoryRouter initialEntries={['/firestore/requests/uniqueRequestId']}>
+        <FirestoreRequests />
+      </MemoryRouter>
+    );
+
+    expect(getByTestId('request-details')).not.toBeNull();
+  });
+
+  it('redirects to /firestore/requests for any other /firestore/requests/:requestId/... path', async () => {
+    const { getByTestId } = render(
+      <MemoryRouter
+        initialEntries={['/firestore/requests/uniqueRequestId/foo']}
+      >
+        <FirestoreRequests />
+      </MemoryRouter>
+    );
+
+    expect(getByTestId('requests-card')).not.toBeNull();
+  });
+});

--- a/src/components/Firestore/Requests/index.tsx
+++ b/src/components/Firestore/Requests/index.tsx
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@rmwc/theme';
+import React from 'react';
+import { Redirect, Route, RouteComponentProps, Switch } from 'react-router-dom';
+
+import { grey100 } from '../../../colors';
+import RequestDetails, { PropsFromParentComponent } from './RequestDetails';
+import RequestsCard from './RequestsCard';
+
+const Requests: React.FC = () => (
+  <ThemeProvider
+    options={{
+      surface: grey100,
+    }}
+  >
+    <Switch>
+      <Route exact path="/firestore/requests">
+        <RequestsCard />
+      </Route>
+      <Route
+        exact
+        path="/firestore/requests/:requestId"
+        render={({ match }: RouteComponentProps<PropsFromParentComponent>) => {
+          const requestId = match.params.requestId;
+          return <RequestDetails requestId={requestId} />;
+        }}
+      />
+      <Redirect to="/firestore/requests" />
+    </Switch>
+  </ThemeProvider>
+);
+
+export default Requests;

--- a/src/components/Firestore/Requests/rules_evaluation_result_model.ts
+++ b/src/components/Firestore/Requests/rules_evaluation_result_model.ts
@@ -61,7 +61,7 @@ export interface FirestoreRulesContext {
   resource?: FirestoreResource;
 }
 
-export type RulesOutcome = 'allow' | 'deny' | 'error';
+export type RulesOutcome = 'allow' | 'deny' | 'error' | 'admin';
 
 export interface FirestoreRulesIssue {
   description: string;
@@ -76,7 +76,7 @@ export interface OutcomeInfo {
 export interface FirestoreRulesUpdateData {
   isCompilationSuccess: boolean;
   issues: FirestoreRulesIssue[];
-  rules: string;
+  rules?: string;
 }
 
 /** This captures everything about the evaluation, including the outcome */

--- a/src/components/Firestore/index.scss
+++ b/src/components/Firestore/index.scss
@@ -17,21 +17,43 @@
 @import '../common/color';
 @import '../common/utils';
 @import '../App/variables';
+@import './variables.scss';
 
 .Firestore {
   display: flex;
   flex-direction: column;
+  position: relative;
 
   // Each panel is individually scrollable within the panel, so we want to avoid
   // making the whole page scrollable by making stuff fit into viewport height.
   height: $app-remaining-viewport-height-for-content;
   // But keep a min-height to keep it usable (at the cost of page scrolling).
-  min-height: 400px;
+  min-height: $firestore-card-min-height;
+}
+
+.Firestore-sub-tabs {
+  margin-bottom: $firestore-sub-tabs-margin-bottom;
+  // shadow border at bottom
+  box-shadow: 0 -1px 0 rgba(0, 0, 0, 0.12) inset;
+
+  .mdc-tab {
+    width: fit-content;
+    height: $firestore-sub-tabs-height;
+    &:not(:first-of-type) {
+      margin-left: 24px;
+    }
+  }
 }
 
 .Firestore-actions {
-  text-align: end;
-  margin-bottom: 24px;
+  position: absolute;
+  right: 0px;
+  top: $firestore-sub-tabs-margin-bottom;
+
+  button {
+    width: fit-content;
+    margin: 6px 0;
+  }
 }
 
 .Firestore-panels-wrapper {

--- a/src/components/Firestore/testing/test_utils.ts
+++ b/src/components/Firestore/testing/test_utils.ts
@@ -18,6 +18,8 @@ import { RenderResult } from '@testing-library/react';
 import firebase from 'firebase';
 
 import { waitForDialogsToOpen } from '../../../test_utils';
+import { FirestoreRulesEvaluation } from '../Requests/rules_evaluation_result_model';
+import { sampleRules } from '../Requests/sample-rules';
 import { renderWithFirestore } from './FirestoreTestProviders';
 
 /*
@@ -32,4 +34,39 @@ export async function renderDialogWithFirestore(
   const result = await renderWithFirestore(ui);
   await waitForDialogsToOpen(result.container);
   return result;
+}
+
+/*
+ * Returns a mocked version of a request evaluation, but also a portion of
+ * an evaluation can be provided to create a custom request evaluation.
+ */
+export function createFakeFirestoreRequestEvaluation(
+  evaluation?: Partial<FirestoreRulesEvaluation>
+): FirestoreRulesEvaluation {
+  return {
+    outcome: 'allow',
+    rulesContext: {
+      request: {
+        method: 'get',
+        path: 'databases/(default)/documents/users/foo',
+        time: new Date().getTime(),
+      },
+      resource: {
+        __name__: 'foo',
+        id: 'database/(default)/documents/users/foo',
+        data: {
+          name: 'Foo Bar',
+          accountAge: 94,
+        },
+      },
+    },
+    requestId: 'unique_id',
+    granularAllowOutcomes: [],
+    data: {
+      isCompilationSuccess: true,
+      rules: sampleRules,
+      issues: [],
+    },
+    ...evaluation,
+  };
 }

--- a/src/components/Firestore/useAutoSelect.test.tsx
+++ b/src/components/Firestore/useAutoSelect.test.tsx
@@ -20,7 +20,7 @@ import React from 'react';
 import { Route, Router } from 'react-router-dom';
 
 import { delay } from '../../test_utils';
-import { useAutoSelect } from './useAutoSelect';
+import { FIRESTORE_DATA_URL, useAutoSelect } from './useAutoSelect';
 
 interface TestData {
   id: string;
@@ -37,215 +37,235 @@ const EMPTY: Array<{ id: string }> = [];
 // TODO: Find some other way to test hooks (e.g. using
 // react-hooks-testing-library) that does not need artificial delays on init.
 describe('useAutoSelect', () => {
-  describe('at /firestore', () => {
+  describe(`at ${FIRESTORE_DATA_URL}`, () => {
     it('does not redirect if the list is null', async () => {
-      const history = createMemoryHistory({ initialEntries: ['/firestore'] });
+      const history = createMemoryHistory({
+        initialEntries: [FIRESTORE_DATA_URL],
+      });
       render(
         <Router history={history}>
-          <Route path="/firestore">
+          <Route path={FIRESTORE_DATA_URL}>
             <Test list={null} />
           </Route>
         </Router>
       );
       await act(() => delay(100));
-      expect(history.location.pathname).toBe('/firestore');
+      expect(history.location.pathname).toBe(FIRESTORE_DATA_URL);
     });
 
     it('does not redirect if there is nothing to select', async () => {
-      const history = createMemoryHistory({ initialEntries: ['/firestore'] });
+      const history = createMemoryHistory({
+        initialEntries: [FIRESTORE_DATA_URL],
+      });
       render(
         <Router history={history}>
-          <Route path="/firestore">
+          <Route path={FIRESTORE_DATA_URL}>
             <Test list={EMPTY} />
           </Route>
         </Router>
       );
       await act(() => delay(100));
-      expect(history.location.pathname).toBe('/firestore');
+      expect(history.location.pathname).toBe(FIRESTORE_DATA_URL);
     });
 
     it('does not redirect if there is something selected', async () => {
       const history = createMemoryHistory({
-        initialEntries: ['/firestore/x'],
+        initialEntries: [`${FIRESTORE_DATA_URL}/x`],
       });
       render(
         <Router history={history}>
-          <Route path="/firestore">
+          <Route path={FIRESTORE_DATA_URL}>
             <Test list={EMPTY} />
           </Route>
         </Router>
       );
       await act(() => delay(100));
-      expect(history.location.pathname).toBe('/firestore/x');
+      expect(history.location.pathname).toBe(`${FIRESTORE_DATA_URL}/x`);
     });
 
     it('redirects to the first child', async () => {
-      const history = createMemoryHistory({ initialEntries: ['/firestore'] });
+      const history = createMemoryHistory({
+        initialEntries: [FIRESTORE_DATA_URL],
+      });
       render(
         <Router history={history}>
-          <Route path="/firestore">
+          <Route path={FIRESTORE_DATA_URL}>
             <Test list={WITH_CHILDREN} />
           </Route>
         </Router>
       );
       await act(() => delay(100));
-      expect(history.location.pathname).toBe('/firestore/first');
+      expect(history.location.pathname).toBe(`${FIRESTORE_DATA_URL}/first`);
     });
 
     it('redirects to the first child with encoded special characters', async () => {
-      const history = createMemoryHistory({ initialEntries: ['/firestore'] });
+      const history = createMemoryHistory({
+        initialEntries: [FIRESTORE_DATA_URL],
+      });
       render(
         <Router history={history}>
-          <Route path="/firestore">
+          <Route path={FIRESTORE_DATA_URL}>
             <Test list={WITH_CHILDREN_ENCODED} />
           </Route>
         </Router>
       );
       await act(() => delay(100));
-      expect(history.location.pathname).toBe('/firestore/first%40%23%24');
+      expect(history.location.pathname).toBe(
+        `${FIRESTORE_DATA_URL}/first%40%23%24`
+      );
     });
-  }); // at /firestore
+  }); // at FIRESTORE_DATA_URL
 
-  describe('at /firestore/:collectionId', () => {
+  describe(`at ${FIRESTORE_DATA_URL}/:collectionId`, () => {
     it('does not redirect if the list is null', async () => {
       const history = createMemoryHistory({
-        initialEntries: ['/firestore/users'],
+        initialEntries: [`${FIRESTORE_DATA_URL}/users`],
       });
       render(
         <Router history={history}>
-          <Route path="/firestore/users">
+          <Route path={`${FIRESTORE_DATA_URL}/users`}>
             <Test list={null} />
           </Route>
         </Router>
       );
       await act(() => delay(100));
-      expect(history.location.pathname).toBe('/firestore/users');
+      expect(history.location.pathname).toBe(`${FIRESTORE_DATA_URL}/users`);
     });
 
     it('does not redirect if there is nothing to select', async () => {
       const history = createMemoryHistory({
-        initialEntries: ['/firestore/users'],
+        initialEntries: [`${FIRESTORE_DATA_URL}/users`],
       });
       render(
         <Router history={history}>
-          <Route path="/firestore/users">
+          <Route path={`${FIRESTORE_DATA_URL}/users`}>
             <Test list={EMPTY} />
           </Route>
         </Router>
       );
       await act(() => delay(100));
-      expect(history.location.pathname).toBe('/firestore/users');
+      expect(history.location.pathname).toBe(`${FIRESTORE_DATA_URL}/users`);
     });
 
     it('does not redirect if there is something selected', async () => {
       const history = createMemoryHistory({
-        initialEntries: ['/firestore/users/x'],
+        initialEntries: [`${FIRESTORE_DATA_URL}/users/x`],
       });
       render(
         <Router history={history}>
-          <Route path="/firestore/users">
+          <Route path={`${FIRESTORE_DATA_URL}/users`}>
             <Test list={EMPTY} />
           </Route>
         </Router>
       );
       await act(() => delay(100));
-      expect(history.location.pathname).toBe('/firestore/users/x');
+      expect(history.location.pathname).toBe(`${FIRESTORE_DATA_URL}/users/x`);
     });
 
     it('redirects to the first child', async () => {
       const history = createMemoryHistory({
-        initialEntries: ['/firestore/users'],
+        initialEntries: [`${FIRESTORE_DATA_URL}/users`],
       });
       render(
         <Router history={history}>
-          <Route path="/firestore/users">
+          <Route path={`${FIRESTORE_DATA_URL}/users`}>
             <Test list={WITH_CHILDREN} />
           </Route>
         </Router>
       );
       await act(() => delay(100));
-      expect(history.location.pathname).toBe('/firestore/users/first');
+      expect(history.location.pathname).toBe(
+        `${FIRESTORE_DATA_URL}/users/first`
+      );
     });
 
     it('redirects to the first child with encoded special characters', async () => {
       const history = createMemoryHistory({
-        initialEntries: ['/firestore/users'],
+        initialEntries: [`${FIRESTORE_DATA_URL}/users`],
       });
       render(
         <Router history={history}>
-          <Route path="/firestore/users">
+          <Route path={`${FIRESTORE_DATA_URL}/users`}>
             <Test list={WITH_CHILDREN_ENCODED} />
           </Route>
         </Router>
       );
       await act(() => delay(100));
-      expect(history.location.pathname).toBe('/firestore/users/first%40%23%24');
+      expect(history.location.pathname).toBe(
+        `${FIRESTORE_DATA_URL}/users/first%40%23%24`
+      );
     });
-  }); // at /firestore/:collectionId
+  }); // at FIRESTORE_DATA_URL/:collectionId
 
-  describe('elsewhere below /firestore/a/b/x', () => {
+  describe(`elsewhere below ${FIRESTORE_DATA_URL}/a/b/x`, () => {
     it('does not redirect if the list is null', async () => {
       const history = createMemoryHistory({
-        initialEntries: ['/firestore/users/alice/friends'],
+        initialEntries: [`${FIRESTORE_DATA_URL}/users/alice/friends`],
       });
       render(
         <Router history={history}>
-          <Route path="/firestore/users/alice/friends">
+          <Route path={`${FIRESTORE_DATA_URL}/users/alice/friends`}>
             <Test list={null} />
           </Route>
         </Router>
       );
       await act(() => delay(100));
-      expect(history.location.pathname).toBe('/firestore/users/alice/friends');
+      expect(history.location.pathname).toBe(
+        `${FIRESTORE_DATA_URL}/users/alice/friends`
+      );
     });
 
     it('does not redirect if there is nothing to select', async () => {
       const history = createMemoryHistory({
-        initialEntries: ['/firestore/users/alice/friends'],
+        initialEntries: [`${FIRESTORE_DATA_URL}/users/alice/friends`],
       });
       render(
         <Router history={history}>
-          <Route path="/firestore/users/alice/friends">
-            <Test list={EMPTY} />
-          </Route>
-        </Router>
-      );
-      await act(() => delay(100));
-      expect(history.location.pathname).toBe('/firestore/users/alice/friends');
-    });
-
-    it('does not redirect if there is something selected', async () => {
-      const history = createMemoryHistory({
-        initialEntries: ['/firestore/users/alice/friends/x'],
-      });
-      render(
-        <Router history={history}>
-          <Route path="/firestore/users/alice/friends">
+          <Route path={`${FIRESTORE_DATA_URL}/users/alice/friends`}>
             <Test list={EMPTY} />
           </Route>
         </Router>
       );
       await act(() => delay(100));
       expect(history.location.pathname).toBe(
-        '/firestore/users/alice/friends/x'
+        `${FIRESTORE_DATA_URL}/users/alice/friends`
+      );
+    });
+
+    it('does not redirect if there is something selected', async () => {
+      const history = createMemoryHistory({
+        initialEntries: [`${FIRESTORE_DATA_URL}/users/alice/friends/x`],
+      });
+      render(
+        <Router history={history}>
+          <Route path={`${FIRESTORE_DATA_URL}/users/alice/friends`}>
+            <Test list={EMPTY} />
+          </Route>
+        </Router>
+      );
+      await act(() => delay(100));
+      expect(history.location.pathname).toBe(
+        `${FIRESTORE_DATA_URL}/users/alice/friends/x`
       );
     });
 
     it('does not redirect when there is nothing selected', async () => {
       const history = createMemoryHistory({
-        initialEntries: ['/firestore/users/alice/friends'],
+        initialEntries: [`${FIRESTORE_DATA_URL}/users/alice/friends`],
       });
       render(
         <Router history={history}>
-          <Route path="/firestore/users/alice/friends">
+          <Route path={`${FIRESTORE_DATA_URL}/users/alice/friends`}>
             <Test list={WITH_CHILDREN} />
           </Route>
         </Router>
       );
       await act(() => delay(100));
-      expect(history.location.pathname).toBe('/firestore/users/alice/friends');
+      expect(history.location.pathname).toBe(
+        `${FIRESTORE_DATA_URL}/users/alice/friends`
+      );
     });
-  }); // elsewhere below /firestore/a/b/x
+  }); // elsewhere below FIRESTORE_DATA_URL/a/b/x
 
   describe('other routes', () => {
     it('does not redirect at /', async () => {

--- a/src/components/Firestore/useAutoSelect.tsx
+++ b/src/components/Firestore/useAutoSelect.tsx
@@ -18,11 +18,12 @@ import { ReactNode, useEffect, useState } from 'react';
 import React from 'react';
 import { Redirect, useLocation, useRouteMatch } from 'react-router-dom';
 
-const FIRESTORE_ROUTE = '/firestore';
+export const FIRESTORE_DATA_URL = '/firestore/data';
+const FIRESTORE_DATA_URL_PATH_LENGTH = FIRESTORE_DATA_URL.split('/').length;
 
 /**
  * Given a list of collections or documents, auto select the first item. Only
- * works on root (`/firestore`) or top level collections (`/firestore/users`)
+ * works on root (`/firestore/data`) or top level collections (`/firestore/data/users`)
  * to prevent deep auto selection.
  */
 export function useAutoSelect<T extends { id: string }>(list?: T[] | null) {
@@ -32,9 +33,10 @@ export function useAutoSelect<T extends { id: string }>(list?: T[] | null) {
 
   useEffect(() => {
     const isRootOrRootCollection =
-      url === FIRESTORE_ROUTE ||
-      // /firestore/users
-      (url.startsWith(FIRESTORE_ROUTE) && url.split('/').length === 3);
+      url === FIRESTORE_DATA_URL ||
+      // /firestore/data/users
+      (url.startsWith(FIRESTORE_DATA_URL) &&
+        url.split('/').length === FIRESTORE_DATA_URL_PATH_LENGTH + 1);
     const hasNothingSelected = url === pathname;
     const firstChild = list?.[0];
     const shouldAutoSelect = isRootOrRootCollection && hasNothingSelected;

--- a/src/components/Firestore/variables.scss
+++ b/src/components/Firestore/variables.scss
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// firestore card
+$firestore-card-min-height: 400px;
+
+// firestore sub tabs
+$firestore-sub-tabs-height: 48px;
+$firestore-sub-tabs-margin-bottom: 48px;
+$firestore-sub-tabs-total-height: (
+  $firestore-sub-tabs-height + $firestore-sub-tabs-margin-bottom
+);

--- a/src/components/LogViewer/History.tsx
+++ b/src/components/LogViewer/History.tsx
@@ -32,7 +32,7 @@ const formatTimestamp = (timestamp: number) => {
   const segments = [date.getHours(), date.getMinutes(), date.getSeconds()];
 
   return segments
-    .map(segment => {
+    .map((segment) => {
       const number = segment.toString();
 
       if (number.length === 2) return number;
@@ -95,7 +95,7 @@ export const History: React.FC<Props> = ({
   log,
   compiledGetters,
 }) => {
-  const history = log.history.filter(log =>
+  const history = log.history.filter((log) =>
     isQueryMatch(parsedQuery, log, compiledGetters)
   );
 
@@ -103,7 +103,7 @@ export const History: React.FC<Props> = ({
 
   const scrollToBottom = () => {
     if (messagesEndRef && messagesEndRef.current) {
-      (messagesEndRef.current as any).scrollIntoView();
+      (messagesEndRef.current as any).scrollIntoView?.();
     }
   };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,8 +29,11 @@ import { BrowserRouter, Route, Switch } from 'react-router-dom';
 
 import { background, primary, secondary } from './colors';
 import App from './components/App';
+import { FirestoreRulesEvaluation } from './components/Firestore/Requests/rules_evaluation_result_model';
+import { registerForRulesEvents } from './components/Firestore/Requests/rules_evaluations_listener';
 import configureStore from './configureStore';
 import { subscribe as subscribeToConfig } from './store/config';
+import { addRequestEvaluation } from './store/firestoreRequestEvaluations';
 import { error } from './themes';
 
 const store = configureStore();
@@ -39,6 +42,23 @@ const RouterWithInit = () => {
   useEffect(() => {
     store.dispatch(subscribeToConfig());
   }, []); // Empty-array means "run only once on init": https://reactjs.org/docs/hooks-effect.html#tip-optimizing-performance-by-skipping-effects
+
+  // Initialize global subscription to firestore requests evaluation
+  useEffect(() => {
+    const callbackFunction = (newRequest: FirestoreRulesEvaluation) => {
+      const { type } = newRequest;
+      if (type === 'RULES_UPDATE') {
+        // TODO: Should we do something when rules are updated?
+      } else {
+        store.dispatch(addRequestEvaluation(newRequest));
+      }
+    };
+    const unsubscribeFromFirestoreRules = registerForRulesEvents(
+      callbackFunction
+    );
+    return () => unsubscribeFromFirestoreRules();
+  }, []);
+
   return (
     <BrowserRouter>
       <Switch>

--- a/src/store/firestoreRequestEvaluations/reducers.test.ts
+++ b/src/store/firestoreRequestEvaluations/reducers.test.ts
@@ -14,46 +14,27 @@
  * limitations under the License.
  */
 
-import { FirestoreRulesEvaluation } from '../../components/Firestore/Requests/rules_evaluation_result_model';
+import { createFakeFirestoreRequestEvaluation } from '../../components/Firestore/testing/test_utils';
 import { addRequestEvaluation } from './actions';
 import {
   FirestoreRequestEvaluationsState,
   firestoreRequestEvaluationsReducer,
 } from './reducer';
 
-const dummyRequestEvaluation: FirestoreRulesEvaluation = {
-  outcome: 'allow',
-  rulesContext: {
-    request: {
-      method: 'get',
-      path: 'databases/(default)/documents/users/foo',
-      time: new Date().getTime(),
-    },
-    resource: {
-      __name__: 'foo',
-      id: 'database/(default)/documents/users/foo',
-      data: {
-        name: 'Foo Bar',
-        accountAge: 94,
-      },
-    },
-  },
-  requestId: 'unique_id',
-  granularAllowOutcomes: [],
-};
-
 describe('firestore request evaluations reducer', () => {
   const INIT_STATE: FirestoreRequestEvaluationsState = [];
+  const dummyRequestEvaluation = createFakeFirestoreRequestEvaluation({
+    requestId: 'first-dummy',
+  });
+  const secondDummyRequestEvaluation = createFakeFirestoreRequestEvaluation({
+    requestId: 'second-dummy',
+  });
 
   it(`${addRequestEvaluation} => adds request evaluation to beginning of array`, () => {
     const updatedState = firestoreRequestEvaluationsReducer(
       INIT_STATE,
       addRequestEvaluation(dummyRequestEvaluation)
     );
-    const secondDummyRequestEvaluation = {
-      ...dummyRequestEvaluation,
-      requestId: 'second-dummy',
-    };
 
     expect(
       firestoreRequestEvaluationsReducer(

--- a/src/test_utils.tsx
+++ b/src/test_utils.tsx
@@ -163,3 +163,8 @@ export const wrapWithForm = <P, T, F = UseFormOptions<T>>(
 
   return { ...methods, triggerValidation, submit };
 };
+
+export function isTabActive(labelEl: HTMLElement): boolean {
+  const tabEl = labelEl.closest('.mdc-tab');
+  return !!tabEl?.classList.contains('mdc-tab--active');
+}


### PR DESCRIPTION
This is the **3rd content PR** created to review the code of my intern project.

This PR focuses on creating a **global subscription** to the websocket that receives request evaluations on real-time.

This solution is just temporal, since later the global subscription will have to be handled using **sagas** side-effects.

In addition to the global subscription, the code to simulate **admin** and **error** request evaluations was added by injecting mock data to incoming request evaluations. This code is useful for development purposes, but will be deleted once the server handles admin and error requests.