### PR TITLE
PR-Firestore-Request-Details

### DIFF
--- a/src/components/Firestore/Requests/RequestDetails/CodeViewer.tsx
+++ b/src/components/Firestore/Requests/RequestDetails/CodeViewer.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/Firestore/Requests/RequestDetails/CodeViewer.tsx
+++ b/src/components/Firestore/Requests/RequestDetails/CodeViewer.tsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ThemeProvider } from '@rmwc/theme';
+import React from 'react';
+
+import { errorTheme, successTheme } from '../../../../themes';
+import {
+  FirestoreRulesIssue,
+  OutcomeInfo,
+} from '../rules_evaluation_result_model';
+
+interface Props {
+  firestoreRules?: string;
+  linesOutcome?: OutcomeInfo[];
+  linesIssues?: FirestoreRulesIssue[];
+}
+
+const CodeViewer: React.FC<Props> = ({
+  firestoreRules,
+  linesOutcome,
+  linesIssues,
+}) => (
+  <ThemeProvider
+    options={{
+      successThemePrimary: successTheme.primary,
+      successThemeBackground: successTheme.background,
+      errorThemePrimary: errorTheme.primary,
+      errorThemeBackground: errorTheme.background,
+    }}
+  >
+    <div
+      data-testid="request-details-code-viewer"
+      className="Firestore-Request-Details-Code"
+    >
+      Code Viewer
+    </div>
+  </ThemeProvider>
+);
+
+export default CodeViewer;

--- a/src/components/Firestore/Requests/RequestDetails/CodeViewer.tsx
+++ b/src/components/Firestore/Requests/RequestDetails/CodeViewer.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,22 +18,14 @@ import { ThemeProvider } from '@rmwc/theme';
 import React from 'react';
 
 import { errorTheme, successTheme } from '../../../../themes';
-import {
-  FirestoreRulesIssue,
-  OutcomeInfo,
-} from '../rules_evaluation_result_model';
+import { OutcomeInfo } from '../rules_evaluation_result_model';
 
 interface Props {
   firestoreRules?: string;
   linesOutcome?: OutcomeInfo[];
-  linesIssues?: FirestoreRulesIssue[];
 }
 
-const CodeViewer: React.FC<Props> = ({
-  firestoreRules,
-  linesOutcome,
-  linesIssues,
-}) => (
+const CodeViewer: React.FC<Props> = ({ firestoreRules, linesOutcome }) => (
   <ThemeProvider
     options={{
       successThemePrimary: successTheme.primary,

--- a/src/components/Firestore/Requests/RequestDetails/Header.tsx
+++ b/src/components/Firestore/Requests/RequestDetails/Header.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/Firestore/Requests/RequestDetails/Header.tsx
+++ b/src/components/Firestore/Requests/RequestDetails/Header.tsx
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { OutcomeData } from '../types';
+
+interface Props {
+  requestTimeComplete: string | undefined;
+  requestTimeFormatted: string | undefined;
+  requestMethod: string | undefined;
+  resourcePath: string | undefined;
+  outcomeData: OutcomeData | undefined;
+}
+
+const RequestDetailsHeader: React.FC<Props> = ({
+  requestTimeComplete,
+  requestTimeFormatted,
+  requestMethod,
+  resourcePath,
+  outcomeData,
+}) => (
+  <div
+    data-testid="request-details-header"
+    className="Firestore-Request-Details-Header"
+  >
+    Header
+  </div>
+);
+
+export default RequestDetailsHeader;

--- a/src/components/Firestore/Requests/RequestDetails/Header.tsx
+++ b/src/components/Firestore/Requests/RequestDetails/Header.tsx
@@ -19,11 +19,11 @@ import React from 'react';
 import { OutcomeData } from '../types';
 
 interface Props {
-  requestTimeComplete: string | undefined;
-  requestTimeFormatted: string | undefined;
-  requestMethod: string | undefined;
-  resourcePath: string | undefined;
-  outcomeData: OutcomeData | undefined;
+  requestTimeComplete?: string;
+  requestTimeFormatted?: string;
+  requestMethod?: string;
+  resourcePath?: string;
+  outcomeData?: OutcomeData;
 }
 
 const RequestDetailsHeader: React.FC<Props> = ({

--- a/src/components/Firestore/Requests/RequestDetails/Header_variables.scss
+++ b/src/components/Firestore/Requests/RequestDetails/Header_variables.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/Firestore/Requests/RequestDetails/Header_variables.scss
+++ b/src/components/Firestore/Requests/RequestDetails/Header_variables.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,5 @@
  * limitations under the License.
  */
 
-import { CustomThemeType } from '../../../themes';
-
-export interface OutcomeData {
-  theme: CustomThemeType;
-  icon: string;
-  label: string;
-}
-
-export interface InspectionElement {
-  label: string;
-  value: string;
-}
+// Header
+$firestore-request-details-header-height: 52px;

--- a/src/components/Firestore/Requests/RequestDetails/InspectionSection.tsx
+++ b/src/components/Firestore/Requests/RequestDetails/InspectionSection.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/Firestore/Requests/RequestDetails/InspectionSection.tsx
+++ b/src/components/Firestore/Requests/RequestDetails/InspectionSection.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,21 @@
  * limitations under the License.
  */
 
-import { CustomThemeType } from '../../../themes';
+import React from 'react';
 
-export interface OutcomeData {
-  theme: CustomThemeType;
-  icon: string;
-  label: string;
+import { InspectionElement } from '../types';
+
+interface Props {
+  inspectionElements?: InspectionElement[];
 }
 
-export interface InspectionElement {
-  label: string;
-  value: string;
-}
+const InspectionSection: React.FC<Props> = ({ inspectionElements }) => (
+  <div
+    data-testid="request-details-inspection-section"
+    className="Firestore-Request-Details-Inspection"
+  >
+    Inspection Section
+  </div>
+);
+
+export default InspectionSection;

--- a/src/components/Firestore/Requests/RequestDetails/InspectionSection.tsx
+++ b/src/components/Firestore/Requests/RequestDetails/InspectionSection.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,14 @@ import React from 'react';
 import { InspectionElement } from '../types';
 
 interface Props {
-  inspectionElements?: InspectionElement[];
+  inspectionExpressions?: InspectionElement[];
+  inspectionQueryData?: InspectionElement[];
 }
 
-const InspectionSection: React.FC<Props> = ({ inspectionElements }) => (
+const InspectionSection: React.FC<Props> = ({
+  inspectionExpressions,
+  inspectionQueryData,
+}) => (
   <div
     data-testid="request-details-inspection-section"
     className="Firestore-Request-Details-Inspection"

--- a/src/components/Firestore/Requests/RequestDetails/index.scss
+++ b/src/components/Firestore/Requests/RequestDetails/index.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/Firestore/Requests/RequestDetails/index.scss
+++ b/src/components/Firestore/Requests/RequestDetails/index.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,8 @@
   display: flex;
   justify-content: flex-start;
   align-items: stretch;
-  // Overflow behavior
+  // Overflow behavior: (useful to allow children components
+  // to have inner scrolling behavior)
   position: relative;
   overflow: hidden;
   min-height: $firestore-request-details-content-min-height;

--- a/src/components/Firestore/Requests/RequestDetails/index.scss
+++ b/src/components/Firestore/Requests/RequestDetails/index.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 
-import { CustomThemeType } from '../../../themes';
+@import './variables.scss';
 
-export interface OutcomeData {
-  theme: CustomThemeType;
-  icon: string;
-  label: string;
-}
-
-export interface InspectionElement {
-  label: string;
-  value: string;
+.Firestore-Request-Details-Content {
+  width: 100%;
+  // Flex behavior: stretch content vertically
+  display: flex;
+  justify-content: flex-start;
+  align-items: stretch;
+  // Overflow behavior
+  position: relative;
+  overflow: hidden;
+  min-height: $firestore-request-details-content-min-height;
+  height: $firestore-request-details-content-viewport-height;
 }

--- a/src/components/Firestore/Requests/RequestDetails/index.test.tsx
+++ b/src/components/Firestore/Requests/RequestDetails/index.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/Firestore/Requests/RequestDetails/index.test.tsx
+++ b/src/components/Firestore/Requests/RequestDetails/index.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,17 +22,17 @@ import { Router } from 'react-router-dom';
 import { createFakeFirestoreRequestEvaluation } from '../../testing/test_utils';
 import { RequestDetails } from './index';
 
-const fakeEvaluation1_ID = 'first-fake-evaluation';
-const fakeEvaluation1 = createFakeFirestoreRequestEvaluation({
-  requestId: fakeEvaluation1_ID,
+const FAKE_EVALUATION_ID = 'first-fake-evaluation';
+const FAKE_EVALUATION = createFakeFirestoreRequestEvaluation({
+  requestId: FAKE_EVALUATION_ID,
 });
 
 describe('RequestDetails', () => {
   it('renders header', () => {
     const { getByTestId } = render(
       <RequestDetails
-        selectedRequest={fakeEvaluation1}
-        requestId={fakeEvaluation1_ID}
+        selectedRequest={FAKE_EVALUATION}
+        requestId={FAKE_EVALUATION_ID}
       />
     );
     expect(getByTestId('request-details-header')).not.toBeNull();
@@ -41,8 +41,8 @@ describe('RequestDetails', () => {
   it('renders code viewer', () => {
     const { getByTestId } = render(
       <RequestDetails
-        selectedRequest={fakeEvaluation1}
-        requestId={fakeEvaluation1_ID}
+        selectedRequest={FAKE_EVALUATION}
+        requestId={FAKE_EVALUATION_ID}
       />
     );
     expect(getByTestId('request-details-code-viewer')).not.toBeNull();
@@ -51,8 +51,8 @@ describe('RequestDetails', () => {
   it('renders inspection section', () => {
     const { getByTestId } = render(
       <RequestDetails
-        selectedRequest={fakeEvaluation1}
-        requestId={fakeEvaluation1_ID}
+        selectedRequest={FAKE_EVALUATION}
+        requestId={FAKE_EVALUATION_ID}
       />
     );
     expect(getByTestId('request-details-inspection-section')).not.toBeNull();
@@ -60,13 +60,13 @@ describe('RequestDetails', () => {
 
   it('redirects back to requests-table when requestId did not match any existing request', async () => {
     const history = createMemoryHistory({
-      initialEntries: [`/firestore/requests/${fakeEvaluation1_ID}`],
+      initialEntries: [`/firestore/requests/${FAKE_EVALUATION_ID}`],
     });
     render(
       <Router history={history}>
         <RequestDetails
           selectedRequest={undefined}
-          requestId={fakeEvaluation1_ID}
+          requestId={FAKE_EVALUATION_ID}
         />
       </Router>
     );

--- a/src/components/Firestore/Requests/RequestDetails/index.test.tsx
+++ b/src/components/Firestore/Requests/RequestDetails/index.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { createFakeFirestoreRequestEvaluation } from '../../testing/test_utils';
+import { RequestDetails } from './index';
+
+const fakeEvaluation1_ID = 'first-fake-evaluation';
+const fakeEvaluation1 = createFakeFirestoreRequestEvaluation({
+  requestId: fakeEvaluation1_ID,
+});
+
+describe('RequestDetails', () => {
+  it('renders header', () => {
+    const { getByTestId } = render(
+      <RequestDetails
+        selectedRequest={fakeEvaluation1}
+        requestId={fakeEvaluation1_ID}
+      />
+    );
+    expect(getByTestId('request-details-header')).not.toBeNull();
+  });
+
+  it('renders code viewer', () => {
+    const { getByTestId } = render(
+      <RequestDetails
+        selectedRequest={fakeEvaluation1}
+        requestId={fakeEvaluation1_ID}
+      />
+    );
+    expect(getByTestId('request-details-code-viewer')).not.toBeNull();
+  });
+
+  it('renders inspection section', () => {
+    const { getByTestId } = render(
+      <RequestDetails
+        selectedRequest={fakeEvaluation1}
+        requestId={fakeEvaluation1_ID}
+      />
+    );
+    expect(getByTestId('request-details-inspection-section')).not.toBeNull();
+  });
+});

--- a/src/components/Firestore/Requests/RequestDetails/index.test.tsx
+++ b/src/components/Firestore/Requests/RequestDetails/index.test.tsx
@@ -15,7 +15,9 @@
  */
 
 import { render } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
 import React from 'react';
+import { Router } from 'react-router-dom';
 
 import { createFakeFirestoreRequestEvaluation } from '../../testing/test_utils';
 import { RequestDetails } from './index';
@@ -54,5 +56,20 @@ describe('RequestDetails', () => {
       />
     );
     expect(getByTestId('request-details-inspection-section')).not.toBeNull();
+  });
+
+  it('redirects back to requests-table when requestId did not match any existing request', async () => {
+    const history = createMemoryHistory({
+      initialEntries: [`/firestore/requests/${fakeEvaluation1_ID}`],
+    });
+    render(
+      <Router history={history}>
+        <RequestDetails
+          selectedRequest={undefined}
+          requestId={fakeEvaluation1_ID}
+        />
+      </Router>
+    );
+    expect(history.location.pathname).toBe('/firestore/requests');
   });
 });

--- a/src/components/Firestore/Requests/RequestDetails/index.tsx
+++ b/src/components/Firestore/Requests/RequestDetails/index.tsx
@@ -23,10 +23,91 @@ import { Redirect } from 'react-router-dom';
 import { AppState } from '../../../../store';
 import { getSelectedRequestEvaluationById } from '../../../../store/firestore/requests/evaluations/selectors';
 import { RequestDetailsRouteParams } from '../index';
-import { useRequestDetailedData, useRequestMainData } from '../utils';
+import {
+  FirestoreRulesContext,
+  FirestoreRulesEvaluation,
+  FirestoreRulesIssue,
+  OutcomeInfo,
+} from '../rules_evaluation_result_model';
+import { InspectionElement, OutcomeData } from '../types';
+import { OUTCOME_DATA } from '../utils';
 import RequestDetailsCodeViewer from './CodeViewer';
 import RequestDetailsHeader from './Header';
 import RequestDetailsInspectionSection from './InspectionSection';
+
+// TODO: remove this mock array when this data comes from the server
+const INSPECTION_QUERY_DATA: InspectionElement[] = [
+  { label: 'limit', value: '20' },
+  { label: 'orderBy', value: 'total_reviews' },
+  { label: 'where', value: "name == 'Pozole'\navg_review_rate > 4" },
+];
+
+// Combines (granularAllowOutcomes) and (issues) into one array of the same type
+function getLinesOutcome(
+  granularAllowOutcomes: OutcomeInfo[],
+  issues?: FirestoreRulesIssue[]
+): OutcomeInfo[] {
+  return [
+    ...granularAllowOutcomes,
+    ...issues?.map(
+      ({ line }): OutcomeInfo => {
+        return { outcome: 'error', line };
+      }
+    ),
+  ];
+}
+// Transforms the (rulesContext) data into InspectionElements
+function getInspectionExpressions(
+  rulesContext: FirestoreRulesContext
+): InspectionElement[] {
+  return Object.entries(rulesContext).map(
+    ([key, value]): InspectionElement => {
+      return {
+        label: key,
+        value: JSON.stringify(value, null, '\t'),
+      };
+    }
+  );
+}
+interface DetailedRequestData {
+  requestTimeComplete?: string;
+  requestTimeFormatted?: string;
+  requestMethod?: string;
+  resourcePath?: string;
+  outcomeData?: OutcomeData;
+  firestoreRules?: string;
+  linesOutcome?: OutcomeInfo[];
+  inspectionExpressions?: InspectionElement[];
+  inspectionQueryData?: InspectionElement[];
+}
+// Outputs (in a clean format) the request data used by the RequestDetails component
+function getDetailsRequestData(
+  request?: FirestoreRulesEvaluation
+): DetailedRequestData {
+  if (!request) {
+    return {};
+  }
+  const { rulesContext, granularAllowOutcomes, data, outcome } = request;
+  // (time * 1000) converts timestamp units from seconds to milliseconds
+  const timestamp = rulesContext.request.time * 1000;
+  const requestDate = new Date(timestamp);
+  return {
+    requestTimeComplete: requestDate.toLocaleString(),
+    requestTimeFormatted: requestDate.toLocaleTimeString('en-US', {
+      hour12: false,
+    }),
+    requestMethod: rulesContext.request.method,
+    resourcePath: rulesContext.request.path.replace(
+      '/databases/(default)/documents',
+      ''
+    ),
+    outcomeData: OUTCOME_DATA[outcome],
+    firestoreRules: data?.rules,
+    linesOutcome: getLinesOutcome(granularAllowOutcomes, data?.issues),
+    inspectionExpressions: getInspectionExpressions(rulesContext),
+    inspectionQueryData: INSPECTION_QUERY_DATA,
+  };
+}
 
 const mapStateToProps = (
   state: AppState,
@@ -43,19 +124,17 @@ export const RequestDetails: React.FC<Props> = ({
   selectedRequest,
   requestId,
 }) => {
-  const [
+  const {
     requestTimeComplete,
     requestTimeFormatted,
     requestMethod,
     resourcePath,
     outcomeData,
-  ] = useRequestMainData(selectedRequest);
-  const [
     firestoreRules,
     linesOutcome,
-    linesIssues,
-    inspectionElements,
-  ] = useRequestDetailedData(selectedRequest);
+    inspectionExpressions,
+    inspectionQueryData,
+  } = getDetailsRequestData(selectedRequest);
 
   // Redirect to requests-table if (requestId) did not match any existing request
   if (requestId && !selectedRequest) {
@@ -77,10 +156,10 @@ export const RequestDetails: React.FC<Props> = ({
             <RequestDetailsCodeViewer
               firestoreRules={firestoreRules}
               linesOutcome={linesOutcome}
-              linesIssues={linesIssues}
             />
             <RequestDetailsInspectionSection
-              inspectionElements={inspectionElements}
+              inspectionExpressions={inspectionExpressions}
+              inspectionQueryData={inspectionQueryData}
             />
           </div>
         </>

--- a/src/components/Firestore/Requests/RequestDetails/index.tsx
+++ b/src/components/Firestore/Requests/RequestDetails/index.tsx
@@ -57,7 +57,7 @@ export const RequestDetails: React.FC<Props> = ({
     inspectionElements,
   ] = useRequestDetailedData(selectedRequest);
 
-  // Redirect to requests table if selected (requestId) did not match any request
+  // Redirect to requests-table if (requestId) did not match any existing request
   if (requestId && !selectedRequest) {
     return <Redirect to="/firestore/requests" />;
   }

--- a/src/components/Firestore/Requests/RequestDetails/variables.scss
+++ b/src/components/Firestore/Requests/RequestDetails/variables.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/Firestore/Requests/RequestDetails/variables.scss
+++ b/src/components/Firestore/Requests/RequestDetails/variables.scss
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import './Header_variables.scss';
+@import '../variables.scss';
+
+// Details content
+$firestore-request-details-content-min-height: (
+  $firestore-requests-card-min-height - $firestore-request-details-header-height
+);
+// Since the app-...-content variable uses calc(), a SASS interpolation
+// is used in order to nest a calc() function inside another calc() function
+// css structure:            calc( calc(0px + 0px) - 0px)
+$firestore-request-details-content-viewport-height: calc(
+  #{$app-remaining-viewport-height-for-content} - #{$firestore-sub-tabs-total-height +
+    $firestore-request-details-header-height}
+);

--- a/src/components/Firestore/Requests/RequestsCard/Table/TableRow.test.tsx
+++ b/src/components/Firestore/Requests/RequestsCard/Table/TableRow.test.tsx
@@ -23,9 +23,9 @@ import { Router } from 'react-router-dom';
 import { createFakeFirestoreRequestEvaluation } from '../../../testing/test_utils';
 import RequestsTableRow from './TableRow';
 
-const fakeEvaluation1_ID = 'first-fake-evaluation';
-const fakeEvaluation1 = createFakeFirestoreRequestEvaluation({
-  requestId: fakeEvaluation1_ID,
+const FAKE_EVALUATION_ID = 'first-fake-evaluation';
+const FAKE_EVALUATION = createFakeFirestoreRequestEvaluation({
+  requestId: FAKE_EVALUATION_ID,
 });
 
 describe('RequestsTableRow', () => {
@@ -36,8 +36,8 @@ describe('RequestsTableRow', () => {
     const { getByRole } = render(
       <Router history={history}>
         <RequestsTableRow
-          request={fakeEvaluation1}
-          requestId={fakeEvaluation1_ID}
+          request={FAKE_EVALUATION}
+          requestId={FAKE_EVALUATION_ID}
         />
       </Router>
     );
@@ -45,7 +45,7 @@ describe('RequestsTableRow', () => {
       fireEvent.click(getByRole('row'));
     });
     expect(history.location.pathname).toBe(
-      `/firestore/requests/${fakeEvaluation1_ID}`
+      `/firestore/requests/${FAKE_EVALUATION_ID}`
     );
   });
 });

--- a/src/components/Firestore/Requests/RequestsCard/Table/TableRow.tsx
+++ b/src/components/Firestore/Requests/RequestsCard/Table/TableRow.tsx
@@ -60,6 +60,7 @@ interface Props {
   request: FirestoreRulesEvaluation;
   requestId: string;
 }
+
 const RequestTableRow: React.FC<Props> = ({ request, requestId }) => {
   const history = useHistory();
   const {

--- a/src/components/Firestore/Requests/index.test.tsx
+++ b/src/components/Firestore/Requests/index.test.tsx
@@ -25,9 +25,9 @@ import {
 } from '../testing/test_utils';
 import FirestoreRequests from '.';
 
-const fakeEvaluation1_ID = 'fakeEvaluation1_ID';
-const fakeEvaluation1 = createFakeFirestoreRequestEvaluation({
-  requestId: fakeEvaluation1_ID,
+const FAKE_EVALUATION_ID = 'first-fake-evaluation';
+const FAKE_EVALUATION = createFakeFirestoreRequestEvaluation({
+  requestId: FAKE_EVALUATION_ID,
 });
 
 describe('Firestore Requests', () => {
@@ -50,14 +50,14 @@ describe('Firestore Requests', () => {
     const store = getMockFirestoreStore({
       firestore: {
         requests: {
-          evaluations: [fakeEvaluation1],
+          evaluations: [FAKE_EVALUATION],
         },
       },
     });
     const { getByTestId } = render(
       <Provider store={store}>
         <MemoryRouter
-          initialEntries={[`/firestore/requests/${fakeEvaluation1_ID}`]}
+          initialEntries={[`/firestore/requests/${FAKE_EVALUATION_ID}`]}
         >
           <FirestoreRequests />
         </MemoryRouter>
@@ -72,7 +72,7 @@ describe('Firestore Requests', () => {
     const { getByTestId } = render(
       <Provider store={store}>
         <MemoryRouter
-          initialEntries={[`/firestore/requests/${fakeEvaluation1_ID}/foo`]}
+          initialEntries={[`/firestore/requests/${FAKE_EVALUATION_ID}/foo`]}
         >
           <FirestoreRequests />
         </MemoryRouter>

--- a/src/components/Firestore/Requests/index.test.tsx
+++ b/src/components/Firestore/Requests/index.test.tsx
@@ -45,7 +45,8 @@ describe('Firestore Requests', () => {
   });
 
   it('renders request details view when /firestore/requests/:requestId', async () => {
-    // Make sure evaluation with such ID exists
+    // Make sure an evaluation with such ID exists on the store,
+    // otherwise you would be redirected back to the requests table
     const store = getMockFirestoreStore({
       firestore: {
         requests: {

--- a/src/components/Firestore/Requests/index.test.tsx
+++ b/src/components/Firestore/Requests/index.test.tsx
@@ -19,8 +19,16 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 
-import { getMockFirestoreStore } from '../testing/test_utils';
+import {
+  createFakeFirestoreRequestEvaluation,
+  getMockFirestoreStore,
+} from '../testing/test_utils';
 import FirestoreRequests from '.';
+
+const fakeEvaluation1_ID = 'fakeEvaluation1_ID';
+const fakeEvaluation1 = createFakeFirestoreRequestEvaluation({
+  requestId: fakeEvaluation1_ID,
+});
 
 describe('Firestore Requests', () => {
   it('renders requests table when /firestore/requests', async () => {
@@ -37,10 +45,19 @@ describe('Firestore Requests', () => {
   });
 
   it('renders request details view when /firestore/requests/:requestId', async () => {
-    const store = getMockFirestoreStore();
+    // Make sure evaluation with such ID exists
+    const store = getMockFirestoreStore({
+      firestore: {
+        requests: {
+          evaluations: [fakeEvaluation1],
+        },
+      },
+    });
     const { getByTestId } = render(
       <Provider store={store}>
-        <MemoryRouter initialEntries={['/firestore/requests/uniqueRequestId']}>
+        <MemoryRouter
+          initialEntries={[`/firestore/requests/${fakeEvaluation1_ID}`]}
+        >
           <FirestoreRequests />
         </MemoryRouter>
       </Provider>
@@ -54,7 +71,7 @@ describe('Firestore Requests', () => {
     const { getByTestId } = render(
       <Provider store={store}>
         <MemoryRouter
-          initialEntries={['/firestore/requests/uniqueRequestId/foo']}
+          initialEntries={[`/firestore/requests/${fakeEvaluation1_ID}/foo`]}
         >
           <FirestoreRequests />
         </MemoryRouter>

--- a/src/components/Firestore/Requests/index.tsx
+++ b/src/components/Firestore/Requests/index.tsx
@@ -24,9 +24,13 @@ import {
   textBlackSecondary,
   textBlackTernary,
 } from '../../../colors';
-import RequestDetails, { PropsFromParentComponent } from './RequestDetails';
+import RequestDetails from './RequestDetails';
 // import RequestsHeader from './RequestsCard/Header';
 import RequestsTable from './RequestsCard/Table';
+
+export interface RequestDetailsRouteParams {
+  requestId: string;
+}
 
 const Requests: React.FC = () => (
   <ThemeProvider
@@ -48,7 +52,7 @@ const Requests: React.FC = () => (
       <Route
         exact
         path="/firestore/requests/:requestId"
-        render={({ match }: RouteComponentProps<PropsFromParentComponent>) => {
+        render={({ match }: RouteComponentProps<RequestDetailsRouteParams>) => {
           const requestId = match.params.requestId;
           return <RequestDetails requestId={requestId} />;
         }}

--- a/src/components/Firestore/Requests/rules_evaluations_listener.ts
+++ b/src/components/Firestore/Requests/rules_evaluations_listener.ts
@@ -21,7 +21,7 @@ import {
   FirestoreRulesUpdateData,
   RulesOutcome,
 } from './rules_evaluation_result_model';
-import { sampleRules } from './sample-rules';
+import { SAMPLE_RULES } from './sample-rules';
 import { generateId } from './utils';
 
 // TODO: Replace hardcoded websocket URL (used for development purposes only)
@@ -45,7 +45,7 @@ function injectMockPropertiesToEvaluationUpdateData(
   const { issues, isCompilationSuccess } = requestUpdateData || {};
   return {
     isCompilationSuccess: requestUpdateData ? !!isCompilationSuccess : true,
-    rules: customOutcome === 'admin' ? undefined : sampleRules,
+    rules: customOutcome === 'admin' ? undefined : SAMPLE_RULES,
     issues: customOutcome === 'error' ? mockedIssues : issues || [],
   };
 }

--- a/src/components/Firestore/Requests/sample-rules.ts
+++ b/src/components/Firestore/Requests/sample-rules.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export const sampleRules: string = `
+export const SAMPLE_RULES: string = `
 
 rules_version = '2';
 service cloud.firestore {

--- a/src/components/Firestore/testing/test_utils.ts
+++ b/src/components/Firestore/testing/test_utils.ts
@@ -21,7 +21,7 @@ import configureStore from 'redux-mock-store';
 import { AppState } from '../../../store/index';
 import { waitForDialogsToOpen } from '../../../test_utils';
 import { FirestoreRulesEvaluation } from '../Requests/rules_evaluation_result_model';
-import { sampleRules } from '../Requests/sample-rules';
+import { SAMPLE_RULES } from '../Requests/sample-rules';
 import { renderWithFirestore } from './FirestoreTestProviders';
 
 /*
@@ -81,7 +81,7 @@ export function createFakeFirestoreRequestEvaluation(
     granularAllowOutcomes: [],
     data: {
       isCompilationSuccess: true,
-      rules: sampleRules,
+      rules: SAMPLE_RULES,
       issues: [],
     },
     ...evaluation,


### PR DESCRIPTION
This is the **6th PR** created to review the code of my intern project.

This PR focuses on adding the **basic structure of the RequestDetails** view. The content of the view (Header, CodeViewer, and InspectionSection) is empty for now, and it will be added on a separate PR.

About to click a row on the requests table:

![image](https://user-images.githubusercontent.com/34299428/104623757-4d5d4100-5658-11eb-8e6f-31b43ca3f6cb.png)

Redirected to the request details view after clicking the table row:

![image](https://user-images.githubusercontent.com/34299428/104623588-230b8380-5658-11eb-9c3e-97415f97ee2d.png)
