### PR TITLE
fix(deps): drop @types/classnames since classnames has builtin typing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "@firebase/component": "^0.5.0",
     "@testing-library/react": "^11.2.2",
     "@testing-library/react-hooks": "^5.1.2",
-    "@types/classnames": "^2.2.10",
     "@types/lodash.get": "^4.4.6",
     "@types/lodash.isequal": "^4.5.5",
     "@types/react-router-dom": "^5.1.3",


### PR DESCRIPTION
Follow up to #538.