### PR TITLE
Fix Firestore BreadCrumb Home icon being hidden.

### DIFF
--- a/src/components/common/BreadCrumbs.scss
+++ b/src/components/common/BreadCrumbs.scss
@@ -31,7 +31,7 @@
   min-width: 0;
   padding: 0;
 
-  @include a11y-display-on-hover('.mdc-icon-button');
+  @include a11y-display-on-hover('.BreadCrumbs-edit .mdc-icon-button');
 
   .mdc-icon-button {
     &::before,


### PR DESCRIPTION
Before:

![Screen Shot 2021-05-25 at 10 37 19 AM](https://user-images.githubusercontent.com/22875286/119543163-371d6b00-bd45-11eb-8309-6796b5d60970.png)

After (expected):

![Screen Shot 2021-05-25 at 10 37 51 AM](https://user-images.githubusercontent.com/22875286/119543378-7350cb80-bd45-11eb-976e-f7aaedb8ef8b.png)


I've confirmed the "Edit" icon is still working as intended (e.g. hidden by default, shown on hover) on both Firestore and Storage tabs.