### PR TITLE
Add swr-based emulator config hooks.

### DIFF
--- a/src/components/App/AppDisconnected.test.tsx
+++ b/src/components/App/AppDisconnected.test.tsx
@@ -18,13 +18,16 @@ import { render } from '@testing-library/react';
 import React from 'react';
 
 import { Config } from '../../store/config';
+import { TestEmulatorConfigProvider } from '../common/EmulatorConfigProvider';
 import { AppDisconnected } from './AppDisconnected';
 
 const disconnectedText = /All emulators for this project have stopped running/;
 
 it('shows nothing when config is loading', () => {
   const { queryByText } = render(
-    <AppDisconnected configRemote={{ loading: true }} />
+    <TestEmulatorConfigProvider config={undefined}>
+      <AppDisconnected />
+    </TestEmulatorConfigProvider>
   );
   expect(queryByText(disconnectedText)).toBe(null);
 });
@@ -32,21 +35,18 @@ it('shows nothing when config is loading', () => {
 it('shows nothing when config is successfully loaded', () => {
   const sampleConfig: Config = { projectId: 'example' };
   const { queryByText } = render(
-    <AppDisconnected
-      configRemote={{ loading: false, result: { data: sampleConfig } }}
-    />
+    <TestEmulatorConfigProvider config={sampleConfig}>
+      <AppDisconnected />
+    </TestEmulatorConfigProvider>
   );
   expect(queryByText(disconnectedText)).toBe(null);
 });
 
-it('shows alert about disconnected when config has error', () => {
+it('shows alert about disconnected when config is null', () => {
   const { getByText } = render(
-    <AppDisconnected
-      configRemote={{
-        loading: false,
-        result: { error: { message: '(ignored)' } },
-      }}
-    />
+    <TestEmulatorConfigProvider config={null}>
+      <AppDisconnected />
+    </TestEmulatorConfigProvider>
   );
   expect(getByText(disconnectedText)).not.toBe(null);
 });

--- a/src/components/App/AppDisconnected.tsx
+++ b/src/components/App/AppDisconnected.tsx
@@ -16,20 +16,12 @@
 
 import { Dialog, DialogContent, DialogTitle } from '@rmwc/dialog';
 import React from 'react';
-import { connect } from 'react-redux';
 
-import { createStructuredSelector } from '../../store';
-import { getConfig } from '../../store/config/selectors';
-import { hasError } from '../../store/utils';
+import { useIsEmulatorDisabled } from '../common/EmulatorConfigProvider';
 
-export const mapStateToProps = createStructuredSelector({
-  configRemote: getConfig,
-});
-
-export type PropsFromState = ReturnType<typeof mapStateToProps>;
-
-export const AppDisconnected: React.FC<PropsFromState> = ({ configRemote }) => {
-  if (!hasError(configRemote.result)) {
+export const AppDisconnected: React.FC = () => {
+  const disabled = useIsEmulatorDisabled();
+  if (!disabled) {
     return null;
   }
 
@@ -45,4 +37,4 @@ export const AppDisconnected: React.FC<PropsFromState> = ({ configRemote }) => {
   );
 };
 
-export default connect(mapStateToProps)(AppDisconnected);
+export default AppDisconnected;

--- a/src/components/App/index.test.tsx
+++ b/src/components/App/index.test.tsx
@@ -18,44 +18,42 @@ import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
-import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 
-import configureStore from '../../configureStore';
 import {
   delay,
   waitAlertDialogToClose,
   waitAlertDialogToOpen,
 } from '../../test_utils';
 import { alert } from '../common/DialogQueue';
+import { TestEmulatorConfigProvider } from '../common/EmulatorConfigProvider';
 import App from '.';
 
 it('renders without crashing', async () => {
   const div = document.createElement('div');
-  const store = configureStore();
   await act(async () => {
     ReactDOM.render(
-      <Provider store={store}>
+      <TestEmulatorConfigProvider config={{ projectId: 'example' }}>
         <BrowserRouter>
           <App />
         </BrowserRouter>
-      </Provider>,
+      </TestEmulatorConfigProvider>,
       div
     );
     // Wait for async tab indicator changes.
     await delay(100);
+    expect(div.firstChild).not.toBeNull();
     ReactDOM.unmountComponentAtNode(div);
   });
 });
 
 it('shows dialogs in the queue', async () => {
-  const store = configureStore();
   const { getByText } = render(
-    <Provider store={store}>
+    <TestEmulatorConfigProvider config={{ projectId: 'example' }}>
       <BrowserRouter>
         <App />
       </BrowserRouter>
-    </Provider>
+    </TestEmulatorConfigProvider>
   );
 
   await act(() => delay(100)); // Wait for tab indicator async DOM updates.
@@ -69,7 +67,7 @@ it('shows dialogs in the queue', async () => {
   expect(getByText('wowah')).not.toBeNull();
 
   await act(async () => {
-    await fireEvent.click(getByText('OK'));
+    fireEvent.click(getByText('OK'));
   });
 
   await waitAlertDialogToClose();

--- a/src/components/Firestore/FirestoreEmulatedApiProvider.tsx
+++ b/src/components/Firestore/FirestoreEmulatedApiProvider.tsx
@@ -20,7 +20,7 @@ import { FirebaseAppProvider, useFirestore } from 'reactfire';
 import { mutate } from 'swr';
 
 import { useEmulatedFirebaseApp } from '../../firebase';
-import { useFirestoreConfig, useProjectId } from '../../store/config/selectors';
+import { useConfig, useEmulatorConfig } from '../common/EmulatorConfigProvider';
 import { useFetcher, useRequest } from '../common/useRequest';
 import { MissingDocument } from './models';
 
@@ -37,8 +37,7 @@ const FIRESTORE_OPTIONS = {};
 export const FirestoreEmulatedApiProvider: React.FC<{
   disableDevTools?: boolean;
 }> = React.memo(({ children, disableDevTools }) => {
-  // TODO: update config to always have a firestore-config obj
-  const config = useFirestoreConfig()!;
+  const config = useEmulatorConfig('firestore');
   const app = useEmulatedFirebaseApp(
     'firestore',
     FIRESTORE_OPTIONS,
@@ -82,9 +81,8 @@ const FirestoreDevTools: React.FC = React.memo(() => {
 });
 
 function useFirestoreRestApi() {
-  // TODO: update config to always have a firestore-config obj
-  const config = useFirestoreConfig()!;
-  const projectId = useProjectId();
+  const config = useEmulatorConfig('firestore');
+  const { projectId } = useConfig();
   const databaseId = '(default)';
 
   return {

--- a/src/components/Firestore/index.test.tsx
+++ b/src/components/Firestore/index.test.tsx
@@ -18,58 +18,41 @@ import { act, render, waitFor, waitForElement } from '@testing-library/react';
 import React from 'react';
 import { Route } from 'react-router-dom';
 
-import { FirestoreConfig } from '../../store/config';
 import { makeDeferred } from '../../test_utils';
 import { confirm } from '../common/DialogQueue';
+import { TestEmulatorConfigProvider } from '../common/EmulatorConfigProvider';
 import * as emulatedApi from './FirestoreEmulatedApiProvider';
 import { Firestore, FirestoreRoute } from './index';
 import { renderWithFirestore } from './testing/FirestoreTestProviders';
 
 jest.mock('../common/DialogQueue');
 
-const sampleConfig: FirestoreConfig = {
-  host: 'localhost',
-  port: 8080,
-  hostAndPort: 'localhost:8080',
-};
-
 describe('FirestoreRoute', () => {
-  it('renders loading when projectId is not ready', () => {
-    const { getByText } = render(
-      <FirestoreRoute
-        projectIdResult={undefined}
-        configResult={{ data: sampleConfig }}
-      />
-    );
-    expect(getByText('Firestore Emulator Loading...')).not.toBeNull();
-  });
-
   it('renders loading when config is not ready', () => {
     const { getByText } = render(
-      <FirestoreRoute
-        projectIdResult={{ data: 'foo' }}
-        configResult={undefined}
-      />
+      <TestEmulatorConfigProvider config={undefined}>
+        <FirestoreRoute />
+      </TestEmulatorConfigProvider>
     );
     expect(getByText('Firestore Emulator Loading...')).not.toBeNull();
   });
 
-  it('renders error when loading config fails', () => {
+  it('renders error when emulators are disabled', () => {
     const { getByText } = render(
-      <FirestoreRoute
-        projectIdResult={{ data: 'foo' }}
-        configResult={{ error: { message: 'Oh, snap!' } }}
-      />
+      <TestEmulatorConfigProvider config={null}>
+        <FirestoreRoute />
+      </TestEmulatorConfigProvider>
     );
     expect(getByText(/not running/)).not.toBeNull();
   });
 
   it('renders "emulator is off" when config is not present', () => {
     const { getByText } = render(
-      <FirestoreRoute
-        projectIdResult={{ data: 'foo' }}
-        configResult={{ data: undefined /* emulator absent */ }}
-      />
+      <TestEmulatorConfigProvider
+        config={{ projectId: 'example' /* no firestore */ }}
+      >
+        <FirestoreRoute />
+      </TestEmulatorConfigProvider>
     );
     expect(getByText(/not running/)).not.toBeNull();
   });

--- a/src/components/Firestore/testing/FirestoreTestProviders.tsx
+++ b/src/components/Firestore/testing/FirestoreTestProviders.tsx
@@ -23,6 +23,7 @@ import { useFirestore } from 'reactfire';
 import configureStore from 'redux-mock-store';
 
 import { AppState } from '../../../store';
+import { TestEmulatorConfigProvider } from '../../common/EmulatorConfigProvider';
 import { FirestoreEmulatedApiProvider } from '../FirestoreEmulatedApiProvider';
 
 interface RenderOptions {
@@ -59,20 +60,14 @@ export const FirestoreTestProviders: React.FC<RenderOptions> = React.memo(
       throw new Error('FirestoreTestProviders requires a running Emulator');
     }
     const [host, port] = hostAndPort.split(':');
-    const store = configureStore<Pick<AppState, 'config'>>()({
-      config: {
-        loading: false,
-        result: {
-          data: {
-            projectId,
-            firestore: { hostAndPort, host, port: Number(port) },
-          },
-        },
-      },
-    });
 
     return (
-      <Provider store={store}>
+      <TestEmulatorConfigProvider
+        config={{
+          projectId,
+          firestore: { host, port: Number(port), hostAndPort },
+        }}
+      >
         <FirestoreEmulatedApiProvider disableDevTools>
           <MemoryRouter initialEntries={[path]}>
             <Suspense fallback={<h1 data-testid="fallback">Fallback</h1>}>
@@ -80,7 +75,7 @@ export const FirestoreTestProviders: React.FC<RenderOptions> = React.memo(
             </Suspense>
           </MemoryRouter>
         </FirestoreEmulatedApiProvider>
-      </Provider>
+      </TestEmulatorConfigProvider>
     );
   }
 );

--- a/src/components/Home/index.test.tsx
+++ b/src/components/Home/index.test.tsx
@@ -18,12 +18,18 @@ import { getByRole, getByText, render } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
 
+import {
+  EmulatorConfigProvider,
+  TestEmulatorConfigProvider,
+} from '../common/EmulatorConfigProvider';
 import { Home } from './index';
 
 it('renders fetching placeholder when fetching config', () => {
   const { getByText } = render(
     <MemoryRouter>
-      <Home configRemote={{ loading: true }} />
+      <TestEmulatorConfigProvider config={undefined}>
+        <Home />
+      </TestEmulatorConfigProvider>
     </MemoryRouter>
   );
   expect(getByText('Overview Page Loading...')).not.toBeNull();
@@ -32,12 +38,9 @@ it('renders fetching placeholder when fetching config', () => {
 it('renders an overview when config is loaded', () => {
   const { getByText } = render(
     <MemoryRouter>
-      <Home
-        configRemote={{
-          loading: false,
-          result: { data: { projectId: 'example' } },
-        }}
-      />
+      <TestEmulatorConfigProvider config={{ projectId: 'example' }}>
+        <Home />
+      </TestEmulatorConfigProvider>
     </MemoryRouter>
   );
   expect(getByText('Emulator overview')).not.toBeNull();
@@ -46,21 +49,18 @@ it('renders an overview when config is loaded', () => {
 it('shows port for emulator that are loaded and N/A for not loaded', () => {
   const { getByTestId } = render(
     <MemoryRouter>
-      <Home
-        configRemote={{
-          loading: false,
-          result: {
-            data: {
-              projectId: 'example',
-              database: {
-                host: 'localhost',
-                port: 9000,
-                hostAndPort: 'localhost:9000',
-              },
-            },
+      <TestEmulatorConfigProvider
+        config={{
+          projectId: 'example',
+          database: {
+            host: 'localhost',
+            port: 9000,
+            hostAndPort: 'localhost:9000',
           },
         }}
-      />
+      >
+        <Home />
+      </TestEmulatorConfigProvider>
     </MemoryRouter>
   );
   // Database Emulator is running.
@@ -77,21 +77,18 @@ it('shows port for emulator that are loaded and N/A for not loaded', () => {
 it('shows hosting emulator card', () => {
   const { getByTestId } = render(
     <MemoryRouter>
-      <Home
-        configRemote={{
-          loading: false,
-          result: {
-            data: {
-              projectId: 'example',
-              hosting: {
-                host: 'localhost',
-                port: 5000,
-                hostAndPort: 'localhost:5000',
-              },
-            },
+      <TestEmulatorConfigProvider
+        config={{
+          projectId: 'example',
+          hosting: {
+            host: 'localhost',
+            port: 5000,
+            hostAndPort: 'localhost:5000',
           },
         }}
-      />
+      >
+        <Home />
+      </TestEmulatorConfigProvider>
     </MemoryRouter>
   );
 
@@ -103,21 +100,18 @@ it('shows hosting emulator card', () => {
 it('links to the hosting website externally', () => {
   const { getByTestId } = render(
     <MemoryRouter>
-      <Home
-        configRemote={{
-          loading: false,
-          result: {
-            data: {
-              projectId: 'example',
-              hosting: {
-                host: 'localhost',
-                port: 5000,
-                hostAndPort: 'localhost:5000',
-              },
-            },
+      <TestEmulatorConfigProvider
+        config={{
+          projectId: 'example',
+          hosting: {
+            host: 'localhost',
+            port: 5000,
+            hostAndPort: 'localhost:5000',
           },
         }}
-      />
+      >
+        <Home></Home>
+      </TestEmulatorConfigProvider>
     </MemoryRouter>
   );
 
@@ -133,21 +127,18 @@ it('links to the hosting website externally', () => {
 it('shows pubsub emulator card', () => {
   const { getByTestId } = render(
     <MemoryRouter>
-      <Home
-        configRemote={{
-          loading: false,
-          result: {
-            data: {
-              projectId: 'example',
-              pubsub: {
-                host: 'localhost',
-                port: 8085,
-                hostAndPort: 'localhost:8085',
-              },
-            },
+      <TestEmulatorConfigProvider
+        config={{
+          projectId: 'example',
+          pubsub: {
+            host: 'localhost',
+            port: 8085,
+            hostAndPort: 'localhost:8085',
           },
         }}
-      />
+      >
+        <Home></Home>
+      </TestEmulatorConfigProvider>
     </MemoryRouter>
   );
 
@@ -158,21 +149,18 @@ it('shows pubsub emulator card', () => {
 it('shows storage emulator card', () => {
   const { getByTestId } = render(
     <MemoryRouter>
-      <Home
-        configRemote={{
-          loading: false,
-          result: {
-            data: {
-              projectId: 'example',
-              storage: {
-                host: 'localhost',
-                port: 9199,
-                hostAndPort: 'localhost:9199',
-              },
-            },
+      <TestEmulatorConfigProvider
+        config={{
+          projectId: 'example',
+          storage: {
+            host: 'localhost',
+            port: 9199,
+            hostAndPort: 'localhost:9199',
           },
         }}
-      />
+      >
+        <Home></Home>
+      </TestEmulatorConfigProvider>
     </MemoryRouter>
   );
 
@@ -184,21 +172,18 @@ it('shows storage emulator card', () => {
 it('shows button for function emulator logs', () => {
   const { getByTestId } = render(
     <MemoryRouter>
-      <Home
-        configRemote={{
-          loading: false,
-          result: {
-            data: {
-              projectId: 'example',
-              functions: {
-                host: 'localhost',
-                port: 5001,
-                hostAndPort: 'localhost:5001',
-              },
-            },
+      <TestEmulatorConfigProvider
+        config={{
+          projectId: 'example',
+          functions: {
+            host: 'localhost',
+            port: 5001,
+            hostAndPort: 'localhost:5001',
           },
         }}
-      />
+      >
+        <Home></Home>
+      </TestEmulatorConfigProvider>
     </MemoryRouter>
   );
   const card = getByTestId(`emulator-info-functions`);
@@ -211,12 +196,9 @@ it('renders all emulators as "off" when error loading config', () => {
   // disconnected overlay. Just keep the layout and show everything as "off".
   const { getByTestId } = render(
     <MemoryRouter>
-      <Home
-        configRemote={{
-          loading: false,
-          result: { error: { message: 'failed to fetch' } },
-        }}
-      />
+      <TestEmulatorConfigProvider config={null}>
+        <Home />
+      </TestEmulatorConfigProvider>
     </MemoryRouter>
   );
 

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -26,13 +26,10 @@ import { GridCell, GridRow } from '@rmwc/grid';
 import { ListDivider } from '@rmwc/list';
 import { Typography } from '@rmwc/typography';
 import React from 'react';
-import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 
-import { createStructuredSelector } from '../../store';
 import { Config, EmulatorConfig } from '../../store/config';
-import { getConfig } from '../../store/config/selectors';
-import { squash } from '../../store/utils';
+import { useConfigOptional } from '../common/EmulatorConfigProvider';
 import {
   AuthIcon,
   DatabaseIcon,
@@ -47,22 +44,16 @@ import { storagePath } from '../Storage/common/constants';
 import { LocalWarningCallout } from './LocalWarningCallout';
 import { StatusLabel } from './StatusLabel';
 
-export const mapStateToProps = createStructuredSelector({
-  configRemote: getConfig,
-});
+export const Home: React.FC = () => {
+  const config = useConfigOptional();
+  if (config === undefined /* initial loading */) {
+    return <Spinner span={12} message="Overview Page Loading..." />;
+  } else {
+    return <Overview config={config || {}} />;
+  }
+};
 
-export type PropsFromState = ReturnType<typeof mapStateToProps>;
-export type Props = PropsFromState;
-
-export const Home: React.FC<Props> = ({ configRemote }) =>
-  squash(configRemote, {
-    onNone: () => <Spinner span={12} message="Overview Page Loading..." />,
-    onData: (config) => <Overview config={config} />,
-    // Show all emulators as "off" on error.
-    onError: () => <Overview config={{}} />,
-  });
-
-export default connect(mapStateToProps)(Home);
+export default Home;
 
 const Overview: React.FC<{
   config: Partial<Config>;

--- a/src/components/Storage/api/useBuckets.test.tsx
+++ b/src/components/Storage/api/useBuckets.test.tsx
@@ -21,7 +21,7 @@ import { Route, Router } from 'react-router-dom';
 
 import { storagePath } from '../common/constants';
 import { mockBuckets } from '../testing/mockBuckets';
-import { StorageStoreProvider } from '../testing/StorageStoreProvider';
+import { TestStorageProvider } from '../testing/TestStorageProvider';
 import { useBuckets } from './useBuckets';
 
 const initialBucketName = 'pirojok-the-bucket';
@@ -38,9 +38,9 @@ describe('useBuckets', () => {
       return (
         <Router history={history}>
           <Route exact path={storagePath + `:bucket/:path*`}>
-            <StorageStoreProvider>
+            <TestStorageProvider>
               <Suspense fallback={'lol'}>{children}</Suspense>
-            </StorageStoreProvider>
+            </TestStorageProvider>
           </Route>
         </Router>
       );

--- a/src/components/Storage/api/useBuckets.tsx
+++ b/src/components/Storage/api/useBuckets.tsx
@@ -16,7 +16,7 @@
 
 import useSWR from 'swr';
 
-import { useStorageConfig } from '../../../store/config/selectors';
+import { useEmulatorConfig } from '../../common/EmulatorConfigProvider';
 import { useBucket } from './useBucket';
 
 export interface Bucket {
@@ -24,11 +24,11 @@ export interface Bucket {
 }
 
 export function useBuckets() {
-  const config = useStorageConfig();
+  const config = useEmulatorConfig('storage');
   const [bucket] = useBucket();
 
   const fetcher = async () => {
-    const response = await fetch('http://' + config!.hostAndPort + '/b');
+    const response = await fetch('http://' + config.hostAndPort + '/b');
     const json = await response.json();
     return json.items.map((b: Bucket) => b.name);
   };

--- a/src/components/Storage/api/useCreateFolder.tsx
+++ b/src/components/Storage/api/useCreateFolder.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useStorageConfig } from '../../../store/config/selectors';
+import { useEmulatorConfig } from '../../common/EmulatorConfigProvider';
 import { useBucket } from './useBucket';
 
 const EMPTY_FOLDER_DATA = `--boundary
@@ -27,7 +27,7 @@ Content-Type: text/plain
 --boundary--`;
 
 export function useCreateFolder() {
-  const config = useStorageConfig();
+  const config = useEmulatorConfig('storage');
   const [bucket] = useBucket();
 
   async function createFolder(fullPath: string) {

--- a/src/components/Storage/api/useTokens.tsx
+++ b/src/components/Storage/api/useTokens.tsx
@@ -16,17 +16,17 @@
 
 import useSWR from 'swr';
 
-import { useStorageConfig } from '../../../store/config/selectors';
+import { useEmulatorConfig } from '../../common/EmulatorConfigProvider';
 import { useBucket } from './useBucket';
 
 export function useTokens(fullPath: string) {
-  const config = useStorageConfig();
+  const config = useEmulatorConfig('storage');
   const [bucket] = useBucket();
   const key = `storage/tokens/${bucket}/${fullPath}`;
 
   const fetcher = async () => {
     const url = `http://${
-      config!.hostAndPort
+      config.hostAndPort
     }/v0/b/${bucket}/o/${encodeURIComponent(fullPath)}`;
 
     const response = await fetch(url, {

--- a/src/components/Storage/index.tsx
+++ b/src/components/Storage/index.tsx
@@ -16,11 +16,9 @@
 
 import { GridCell } from '@rmwc/grid';
 import React, { Suspense } from 'react';
-import { useSelector } from 'react-redux';
 import { Redirect, Route, Switch } from 'react-router-dom';
 
-import { getStorageConfigResult } from '../../store/config/selectors';
-import { handle } from '../../store/utils';
+import { useIsEmulatorDisabled } from '../common/EmulatorConfigProvider';
 import { EmulatorDisabled } from '../common/EmulatorDisabled';
 import { Spinner } from '../common/Spinner';
 import { useBuckets } from './api/useBuckets';
@@ -31,25 +29,13 @@ import styles from './index.module.scss';
 import { StorageFirebaseAppProvider } from './providers/StorageFirebaseAppProvider';
 
 export const Storage: React.FC = () => {
-  const configResult = useSelector(getStorageConfigResult);
-
-  const spinner = <Spinner span={12} message="Storage Emulator Loading..." />;
-
-  return handle(configResult, {
-    onNone: () => spinner,
-    onError: () => <StorageRouteDisabled />,
-    onData: (config) => {
-      return config === undefined ? (
-        <StorageRouteDisabled />
-      ) : (
-        <Suspense fallback={spinner}>
-          <StorageRoute>
-            <StorageWrapper />
-          </StorageRoute>
-        </Suspense>
-      );
-    },
-  });
+  return (
+    <Suspense fallback={<StorageRouteSuspended />}>
+      <StorageRoute>
+        <StorageWrapper />
+      </StorageRoute>
+    </Suspense>
+  );
 };
 
 export const StorageWrapper: React.FC = () => {
@@ -80,6 +66,11 @@ export const StorageRoute: React.FC = ({ children }) => {
   );
 };
 
-export const StorageRouteDisabled: React.FC = () => (
-  <EmulatorDisabled productName="Storage" />
-);
+const StorageRouteSuspended: React.FC = () => {
+  const isDisabled = useIsEmulatorDisabled('storage');
+  return isDisabled ? (
+    <EmulatorDisabled productName="Storage" />
+  ) : (
+    <Spinner span={12} message="Storage Emulator Loading..." />
+  );
+};

--- a/src/components/Storage/providers/StorageFirebaseAppProvider.tsx
+++ b/src/components/Storage/providers/StorageFirebaseAppProvider.tsx
@@ -14,29 +14,30 @@
  * limitations under the License.
  */
 
-import '@firebase/storage';
-
-import React, { useEffect, useMemo } from 'react';
+import React, { useCallback } from 'react';
 import { FirebaseAppProvider } from 'reactfire';
 
-import { getStorageApp } from '../../../firebase';
-import { useStorageConfig } from '../../../store/config/selectors';
+import { useEmulatedFirebaseApp } from '../../../firebase';
+import { useEmulatorConfig } from '../../common/EmulatorConfigProvider';
 
-function useStorageApp() {
-  const { host, port } = useStorageConfig();
-  const app = useMemo(() => getStorageApp(host, port.toString()), [host, port]);
-
-  useEffect(() => {
-    return () => {
-      app.delete();
-    };
-  }, [app]);
-
-  return app;
-}
+const FIREBASE_APP_OPTIONS = {};
 
 export const StorageFirebaseAppProvider: React.FC = ({ children }) => {
-  const app = useStorageApp();
+  const { host, port } = useEmulatorConfig('storage');
+  const app = useEmulatedFirebaseApp(
+    'storage',
+    FIREBASE_APP_OPTIONS,
+    useCallback(
+      (app) => {
+        app.storage().useEmulator(host, port);
+      },
+      [host, port]
+    )
+  );
+
+  if (!app) {
+    return null;
+  }
 
   return (
     <FirebaseAppProvider firebaseApp={app}>{children}</FirebaseAppProvider>

--- a/src/components/Storage/testing/FakeStorageWrappers.tsx
+++ b/src/components/Storage/testing/FakeStorageWrappers.tsx
@@ -18,7 +18,7 @@ import React, { Suspense } from 'react';
 
 import { StorageFirebaseAppProvider } from '../providers/StorageFirebaseAppProvider';
 import { FakeFirebaseRouterProvider } from './FakeFirebaseRouterProvider';
-import { StorageStoreProvider } from './StorageStoreProvider';
+import { TestStorageProvider } from './TestStorageProvider';
 
 export interface StorageTestWrappersProps {
   fallbackTestId: string;
@@ -29,12 +29,12 @@ export const FakeStorageWrappers: React.FC<StorageTestWrappersProps> = ({
   fallbackTestId,
 }) => {
   return (
-    <StorageStoreProvider>
+    <TestStorageProvider>
       <Suspense fallback={<div data-testid={fallbackTestId} />}>
         <StorageFirebaseAppProvider>
           <FakeFirebaseRouterProvider>{children}</FakeFirebaseRouterProvider>
         </StorageFirebaseAppProvider>
       </Suspense>
-    </StorageStoreProvider>
+    </TestStorageProvider>
   );
 };

--- a/src/components/Storage/testing/TestStorageProvider.tsx
+++ b/src/components/Storage/testing/TestStorageProvider.tsx
@@ -15,13 +15,11 @@
  */
 
 import React from 'react';
-import { Provider } from 'react-redux';
-import configureStore from 'redux-mock-store';
 
-import { AppState } from '../../../store';
+import { TestEmulatorConfigProvider } from '../../common/EmulatorConfigProvider';
 
-export const StorageStoreProvider: React.FC = ({ children }) => {
-  const projectId = '';
+export const TestStorageProvider: React.FC = ({ children }) => {
+  const projectId = 'UNUSED';
   const hostAndPort = process.env.FIREBASE_STORAGE_EMULATOR_HOST;
 
   if (!hostAndPort) {
@@ -32,16 +30,14 @@ export const StorageStoreProvider: React.FC = ({ children }) => {
 
   const [host, port] = hostAndPort.split(':');
 
-  const store = configureStore<Pick<AppState, 'config'>>()({
-    config: {
-      loading: false,
-      result: {
-        data: {
-          projectId,
-          storage: { hostAndPort, host, port: Number(port) },
-        },
-      },
-    },
-  });
-  return <Provider store={store}>{children}</Provider>;
+  return (
+    <TestEmulatorConfigProvider
+      config={{
+        projectId,
+        storage: { hostAndPort, host, port: Number(port) },
+      }}
+    >
+      {children}
+    </TestEmulatorConfigProvider>
+  );
 };

--- a/src/components/common/EmulatorConfigProvider.tsx
+++ b/src/components/common/EmulatorConfigProvider.tsx
@@ -1,0 +1,171 @@
+import React, { useEffect, useState } from 'react';
+import useSwr, { mutate } from 'swr';
+
+import { Config, Emulator } from '../../store/config';
+
+const emulatorConfigContext = React.createContext<
+  | {
+      config?: Config | null;
+      promise: Promise<Config | null | undefined>;
+    }
+  | undefined
+>(undefined);
+
+const CONFIG_API = '/api/config';
+
+export function useOnChangePromise<T>(data: T): Promise<T> {
+  // Use only one single state to prevent accidental partial updates.
+  const [state, setState] = useState(() => ({
+    oldData: data,
+    deferred: makeDeferred<T>(),
+  }));
+
+  useEffect(() => {
+    if (data !== state.oldData) {
+      const oldDeferred = state.deferred;
+      setState({
+        oldData: data,
+        deferred: makeDeferred<T>(),
+      });
+      oldDeferred.resolve(data);
+    }
+  }, [data, state, setState]);
+  return state.deferred.promise;
+}
+
+export const EmulatorConfigProvider: React.FC<{ refreshInterval: number }> = ({
+  refreshInterval,
+  children,
+}) => {
+  // We don't use suspense here since the provider should never be suspended --
+  // it merely creates a context for hooks (e.g. useConfig) who do suspend.
+  const { data } = useSwr<Config | null>(CONFIG_API, jsonFetcher, {
+    refreshInterval,
+
+    // Emulator UI works fully offline. Even if the browser cannot reach LAN or
+    // any router, this page and the CONFIG_API will still work if they are on
+    // the same physical device (e.g. localhost/127.0.0.1/containers/VMs). See:
+    // https://developer.mozilla.org/en-US/docs/Web/API/NavigatorOnLine/onLine
+    refreshWhenOffline: true,
+    onErrorRetry(_, __, ___, revalidate, { retryCount }) {
+      if (retryCount < 2) {
+        // If the Emulator Hub is running locally, we are very unlikely to get
+        // any errors at all. However, an occasional blip may happen when using
+        // Emulator UI remotely (or through port forwarding). Let's retry once.
+        // Note that swr will keep `data` while retrying, so UI won't unload.
+        // (This overwrites swr's built-in exponential backoff timeouts.)
+        setTimeout(() => revalidate({ retryCount }), refreshInterval);
+      } else {
+        // We cannot reach the discovery API for 2+ times. This usually means
+        // Emulator Hub is stopped or unreachable. swr won't clear data on error
+        // so we manually set data to null to represent this situation.
+        // Tell swr to revalidate (retry the fetch). No need for setTimeout.
+        mutate(CONFIG_API, null, /* shouldRevalidate= */ true);
+      }
+    },
+  });
+
+  const promise = useOnChangePromise(data);
+
+  return (
+    <emulatorConfigContext.Provider
+      value={{
+        config: data,
+        promise,
+      }}
+    >
+      {children}
+    </emulatorConfigContext.Provider>
+  );
+};
+
+export const TestEmulatorConfigProvider: React.FC<{
+  config: Config | null | undefined;
+}> = ({ config, children }) => {
+  const promise = useOnChangePromise(config);
+  return (
+    <emulatorConfigContext.Provider
+      value={{
+        config,
+        promise,
+      }}
+    >
+      {children}
+    </emulatorConfigContext.Provider>
+  );
+};
+
+export function useConfig(): Config {
+  const context = React.useContext(emulatorConfigContext);
+  if (context === undefined) {
+    throw new Error('useConfig must be used within a <EmulatorConfigProvider>');
+  }
+  if (context.config === undefined) {
+    // Loading. Throw the promise to suspend rendering (to support <Suspense>).
+    throw context.promise;
+  } else if (context.config == null) {
+    // Emulator Suite is disconnected / unreachable.
+    throw context.promise;
+  } else {
+    return context.config;
+  }
+}
+
+export function useEmulatorConfig(
+  emulator: Emulator
+): NonNullable<Config[typeof emulator]> {
+  const config = useConfig();
+  const emulatorConfig = config[emulator];
+  const promise = useOnChangePromise(emulatorConfig);
+  if (emulatorConfig === undefined) {
+    // Emulator Suite is running, but the specified emulator is not running.
+    throw promise;
+  }
+  return emulatorConfig;
+}
+
+export function useIsEmulatorDisabled(emulator?: keyof Config): boolean {
+  const config = useConfigOptional();
+  if (config === undefined) {
+    // Still loading, we cannot tell if emulator is disabled.
+    return false;
+  }
+  if (config === null) {
+    // The whole suite is disconnected, so we show all emulators as disabled.
+    return true;
+  }
+  if (emulator && !config[emulator]) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Try getting Config, but return null if disconnected or undefined if loading.
+ * Should be used very sparingly. Prefer useConfig() for most cases.
+ */
+export function useConfigOptional(): Config | undefined | null {
+  const context = React.useContext(emulatorConfigContext);
+  if (context === undefined) {
+    throw new Error(
+      'useConfigOptional must be used within a <EmulatorConfigProvider>'
+    );
+  }
+  return context.config;
+}
+
+async function jsonFetcher<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Got HTTP status code ${response.status}`);
+  }
+  return response.json();
+}
+
+function makeDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}

--- a/src/components/common/EmulatorConfigProvider.tsx
+++ b/src/components/common/EmulatorConfigProvider.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, { useEffect, useState } from 'react';
 import useSwr, { mutate } from 'swr';
 

--- a/src/components/common/EmulatorConfigProvider.tsx
+++ b/src/components/common/EmulatorConfigProvider.tsx
@@ -29,6 +29,18 @@ const emulatorConfigContext = React.createContext<
 
 const CONFIG_API = '/api/config';
 
+/**
+ * Returns a promise that resolves when the data changes.
+ *
+ * Note: When the argument passed !== previously passed, the previously returned
+ * promise is resolved and a new pending promise is returned (resolved on the
+ * next change).
+ *
+ * @example
+ *   const data = useMyAwesomeDataThatMayChange();
+ *   const promise = useOnChangePromise(data);
+ *   if (!someCondition(data)) throw promise; // use with <Suspense>
+ */
 export function useOnChangePromise<T>(data: T): Promise<T> {
   // Use only one single state to prevent accidental partial updates.
   const [state, setState] = useState(() => ({
@@ -56,6 +68,8 @@ export const EmulatorConfigProvider: React.FC<{ refreshInterval: number }> = ({
   // We don't use suspense here since the provider should never be suspended --
   // it merely creates a context for hooks (e.g. useConfig) who do suspend.
   const { data } = useSwr<Config | null>(CONFIG_API, jsonFetcher, {
+    // Keep refreshing config to detect when emulators are stopped or restarted
+    // with a different config (e.g. different emulators or host / ports).
     refreshInterval,
 
     // Emulator UI works fully offline. Even if the browser cannot reach LAN or

--- a/src/components/common/EmulatorDisabled.tsx
+++ b/src/components/common/EmulatorDisabled.tsx
@@ -42,7 +42,7 @@ export const EmulatorDisabled: React.FC<{
             If you are not using {productName} in your testing, everything is
             fine. If you want to use {productName} in your testing, then the
             best way to set it up and start it is to run the following command
-            initialize the {productName} Emulator:{' '}
+            to initialize the {productName} Emulator:{' '}
             <code>firebase init emulators</code>. Followed by:{' '}
             <code>firebase emulators:start</code>.
           </Typography>

--- a/src/components/common/useRequest.ts
+++ b/src/components/common/useRequest.ts
@@ -45,5 +45,11 @@ export function useRequest<T = unknown>(
   return useSwr<T>(url, fetcher, {
     refreshInterval,
     suspense: true,
+
+    // Emulator UI works fully offline. Even if the browser cannot reach LAN or
+    // any router, this page and the CONFIG_API will still work if they are on
+    // the same physical device (e.g. localhost/127.0.0.1/containers/VMs). See:
+    // https://developer.mozilla.org/en-US/docs/Web/API/NavigatorOnLine/onLine
+    refreshWhenOffline: true,
   });
 }

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -16,6 +16,7 @@
 
 import 'firebase/database';
 import 'firebase/firestore';
+import 'firebase/storage';
 
 import { _FirebaseApp } from '@firebase/app-types/private';
 import { FirebaseAuthInternal } from '@firebase/auth-interop-types';
@@ -55,16 +56,6 @@ export function initDatabase(
   (window as WindowWithDb).database = db;
   return [db, { cleanup: () => app.delete() }];
 }
-
-export const getStorageApp = (host: string, port: string) => {
-  const app = firebase.initializeApp(
-    {},
-    `Storage Component: ${host} ${Math.random()}`
-  ) as any;
-  applyAdminAuth(app);
-  app.storage().useEmulator(host, port);
-  return app;
-};
 
 /**
  * Get a JS SDK App instance with emulator Admin auth enabled.

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -23,8 +23,8 @@ import { Component, ComponentType } from '@firebase/component';
 import firebase from 'firebase/app';
 import { useEffect, useState } from 'react';
 
+import { useConfig } from './components/common/EmulatorConfigProvider';
 import { DatabaseConfig } from './store/config';
-import { useProjectId } from './store/config/selectors';
 
 interface WindowWithDb extends Window {
   database?: firebase.database.Database;
@@ -87,7 +87,7 @@ export function useEmulatedFirebaseApp(
   config?: object,
   initialize?: (app: firebase.app.App) => void
 ): firebase.app.App | undefined {
-  const projectId = useProjectId();
+  const { projectId } = useConfig();
   const [app, setApp] = useState<firebase.app.App | undefined>();
 
   useEffect(() => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,6 +29,7 @@ import { BrowserRouter, Route, Switch } from 'react-router-dom';
 
 import { background, primary, secondary } from './colors';
 import App from './components/App';
+import { EmulatorConfigProvider } from './components/common/EmulatorConfigProvider';
 import configureStore from './configureStore';
 import { subscribe as subscribeToConfig } from './store/config';
 import { error } from './themes';
@@ -63,9 +64,11 @@ ReactDOM.unstable_createBlockingRoot(document.getElementById('root')!).render(
           error,
         }}
       >
-        <Provider store={store}>
-          <RouterWithInit />
-        </Provider>
+        <EmulatorConfigProvider refreshInterval={2000}>
+          <Provider store={store}>
+            <RouterWithInit />
+          </Provider>
+        </EmulatorConfigProvider>
       </ThemeProvider>
     </RMWCProvider>
   </React.StrictMode>

--- a/src/store/config/selectors.ts
+++ b/src/store/config/selectors.ts
@@ -18,7 +18,7 @@ import { useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
 
 import { Result, hasError, map } from '../utils';
-import { EmulatorConfig, FirestoreConfig } from './types';
+import { EmulatorConfig } from './types';
 import { AppState } from '..';
 
 // Get the RemoteResult wrapper for config. If you only care about result,
@@ -58,16 +58,6 @@ function useRemoteResultData<T = {}>(result: Result<T> | undefined) {
     throw new Error(result.error.message);
   }
   return result.data;
-}
-
-export function useProjectId() {
-  const projectId = useSelector(getProjectIdResult);
-  return useRemoteResultData(projectId);
-}
-
-export function useFirestoreConfig() {
-  const config = useSelector(getFirestoreConfigResult);
-  return useRemoteResultData<FirestoreConfig | undefined>(config);
 }
 
 export function useStorageConfig(): EmulatorConfig {

--- a/src/store/config/selectors.ts
+++ b/src/store/config/selectors.ts
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-import { useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
 
-import { Result, hasError, map } from '../utils';
-import { EmulatorConfig } from './types';
+import { map } from '../utils';
 import { AppState } from '..';
 
 // Get the RemoteResult wrapper for config. If you only care about result,
@@ -39,29 +37,3 @@ export const getDatabaseConfigResult = createSelector(
   getConfigResult,
   (result) => map(result, (config) => config.database)
 );
-
-export const getStorageConfigResult = createSelector(
-  getConfigResult,
-  (result) => map(result, (config) => config.storage)
-);
-
-export const getFirestoreConfigResult = createSelector(
-  getConfigResult,
-  (result) => map(result, (config) => config.firestore)
-);
-
-function useRemoteResultData<T = {}>(result: Result<T> | undefined) {
-  if (!result) {
-    throw new Error('Result data requested that is not yet populated');
-  }
-  if (hasError(result)) {
-    throw new Error(result.error.message);
-  }
-  return result.data;
-}
-
-export function useStorageConfig(): EmulatorConfig {
-  const config = useSelector(getStorageConfigResult);
-  // TODO(kirjs): Use assertions
-  return useRemoteResultData<EmulatorConfig | undefined>(config)!;
-}

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -32,6 +32,16 @@ export interface LoggingConfig extends EmulatorConfig {}
 
 export interface AuthConfig extends EmulatorConfig {}
 
+export type Emulator =
+  | 'database'
+  | 'auth'
+  | 'firestore'
+  | 'functions'
+  | 'logging'
+  | 'hosting'
+  | 'storage'
+  | 'pubsub';
+
 export interface Config {
   projectId: string;
   database?: DatabaseConfig;


### PR DESCRIPTION
Progress and plan:

- [x] Add new providers and hooks
- [x] Migrate Home
- [x] Migrate AppDisconnected 
- [x] Migrate Firestore
- [x] Migrate Storage
- [ ] Migrate RTDB (and migrate databases list to `useSwr`, removing redux parts)
- [ ] Migrate Auth (keep Redux locally at least for now)
- [ ] Delete tons of boilerplate for `store/config` + more

----

Note to reviewers:

Start from `src/components/common/EmulatorConfigProvider.tsx` where new stuff is introduced. See `Home` and `AppDisconnected` to see them in action. Then move on to bigger changes like Firestore or Storage. Per-commit view on GitHub can be handy -- for example Storage changes are isolated in their own commit.