### PR TITLE
Allow scrolling while adding or editing fields

### DIFF
--- a/src/components/Firestore/DocumentPreview/InlineEditor.tsx
+++ b/src/components/Firestore/DocumentPreview/InlineEditor.tsx
@@ -73,6 +73,7 @@ const InlineEditor: React.FC<{
       className="Firestore-InlineEditor-relative-anchor"
       onClickOutside={handleCancel}
       onEscapeKey={handleCancel}
+      scrollLock={false}
     >
       <Elevation z={8} wrap>
         <Card


### PR DESCRIPTION
The affected InlineEditor component is being used when adding or editing fields, in the Realtime Database and Firestore tabs.

Fix #467.