### PR TITLE
Fix issue with the order of requests in the Firestore tab

### DIFF
--- a/src/components/Firestore/Requests/RequestsCard/Table/TableRow.tsx
+++ b/src/components/Firestore/Requests/RequestsCard/Table/TableRow.tsx
@@ -41,7 +41,7 @@ function getTableRowRequestData(
 ): TableRowRequestData {
   const { rulesContext, outcome } = request;
   // time * 1000 converts timestamp units from seconds to millis
-  const requestDate = new Date(rulesContext.time);
+  const requestDate = new Date(request.time);
   return {
     requestTimeComplete: requestDate.toLocaleString(),
     requestTimeFormatted: requestDate.toLocaleTimeString('en-US', {

--- a/src/components/Firestore/Requests/RequestsCard/Table/TableRow.tsx
+++ b/src/components/Firestore/Requests/RequestsCard/Table/TableRow.tsx
@@ -39,9 +39,9 @@ interface TableRowRequestData {
 function getTableRowRequestData(
   request: FirestoreRulesEvaluation
 ): TableRowRequestData {
-  const { rulesContext, outcome } = request;
+  const { rulesContext, outcome, time } = request;
   // time * 1000 converts timestamp units from seconds to millis
-  const requestDate = new Date(request.time);
+  const requestDate = new Date(time);
   return {
     requestTimeComplete: requestDate.toLocaleString(),
     requestTimeFormatted: requestDate.toLocaleTimeString('en-US', {

--- a/src/components/Firestore/Requests/RequestsCard/Table/TableRow.tsx
+++ b/src/components/Firestore/Requests/RequestsCard/Table/TableRow.tsx
@@ -40,7 +40,6 @@ function getTableRowRequestData(
   request: FirestoreRulesEvaluation
 ): TableRowRequestData {
   const { rulesContext, outcome, time } = request;
-  // time * 1000 converts timestamp units from seconds to millis
   const requestDate = new Date(time);
   return {
     requestTimeComplete: requestDate.toLocaleString(),

--- a/src/components/Firestore/Requests/rules_evaluation_result_model.ts
+++ b/src/components/Firestore/Requests/rules_evaluation_result_model.ts
@@ -79,4 +79,5 @@ export interface FirestoreRulesEvaluation {
   granularAllowOutcomes: OutcomeInfo[];
   rules?: string;
   rulesReleaseName?: string;
+  time: string;
 }

--- a/src/components/Firestore/testing/test_utils.ts
+++ b/src/components/Firestore/testing/test_utils.ts
@@ -62,7 +62,7 @@ export function createFakeFirestoreRequestEvaluation(
     requestId: 'unique_id',
     granularAllowOutcomes: [],
     rules: SAMPLE_RULES,
-    time: new Date().toString(),
+    time: new Date().toISOString(),
     ...evaluation,
   };
 }

--- a/src/components/Firestore/testing/test_utils.ts
+++ b/src/components/Firestore/testing/test_utils.ts
@@ -62,6 +62,7 @@ export function createFakeFirestoreRequestEvaluation(
     requestId: 'unique_id',
     granularAllowOutcomes: [],
     rules: SAMPLE_RULES,
+    time: new Date().toString(),
     ...evaluation,
   };
 }


### PR DESCRIPTION
By using the root time field, instead of the rulesContext.time field.

The former seems to have the timestamp at which the request was actually sent. On the other hand, the latter apparently keeps the timestamp at which some web socket communication was created. In the case of get-only-once firestore requests, that connection seems to last for 1 minute,

I had to add the time field to the FirestoreRulesEvaluation interface, as it wasn't there. And also, add the time field to the object returned by a testing util function.

Fix #634.