### PR TITLE
Multi-tenancy

### DIFF
--- a/src/components/Auth/UsersCard/TenantPicker.tsx
+++ b/src/components/Auth/UsersCard/TenantPicker.tsx
@@ -39,7 +39,14 @@ export function useTenantFromUrl(): [string, (tenantId: string) => void] {
 const TenantPicker: React.FC<PropsFromStore> = ({ tenants, loading }) => {
   const [tenant, setTenant] = useTenantFromUrl();
 
-  if (loading) {
+  // hide picker if no tenants exist in the emulator
+  if (tenants.length === 0) {
+    return null;
+  }
+
+  // only show loading state if currently selected tenant doesn't exist yet
+  // otherwise, loading can happen in the background
+  if (loading === true && !tenants.includes(tenant)) {
     return (
       <Select
         disabled={true}

--- a/src/components/Auth/UsersCard/TenantPicker.tsx
+++ b/src/components/Auth/UsersCard/TenantPicker.tsx
@@ -20,7 +20,7 @@ import { connect } from 'react-redux';
 import { useHistory, useParams } from 'react-router-dom';
 
 import { createStructuredSelector } from '../../../store';
-import { getTenants } from '../../../store/auth/selectors';
+import { getTenants, getTenantsLoading } from '../../../store/auth/selectors';
 import { MultiTenancyIcon } from '../../common/icons';
 import styles from './UsersCard.module.scss';
 import { authPath } from '..';
@@ -36,11 +36,23 @@ export function useTenantFromUrl(): [string, (tenantId: string) => void] {
   return [tenant, setTenant];
 }
 
-const TenantPicker: React.FC<PropsFromStore> = ({ tenants }) => {
+const TenantPicker: React.FC<PropsFromStore> = ({ tenants, loading }) => {
   const [tenant, setTenant] = useTenantFromUrl();
+
+  if (loading) {
+    return (
+      <Select
+        disabled={true}
+        icon={<MultiTenancyIcon />}
+        className={styles.tenantPicker}
+        aria-label="Tenant picker loading"
+      />
+    );
+  }
 
   return (
     <Select
+      disabled={false}
       icon={<MultiTenancyIcon />}
       className={styles.tenantPicker}
       value={tenant ?? 'Default tenant'}
@@ -59,6 +71,7 @@ const TenantPicker: React.FC<PropsFromStore> = ({ tenants }) => {
 
 export const mapStateToProps = createStructuredSelector({
   tenants: getTenants,
+  loading: getTenantsLoading,
 });
 
 export type PropsFromStore = ReturnType<typeof mapStateToProps>;

--- a/src/components/Auth/UsersCard/TenantPicker.tsx
+++ b/src/components/Auth/UsersCard/TenantPicker.tsx
@@ -43,12 +43,12 @@ const TenantPicker: React.FC<PropsFromStore> = ({ tenants }) => {
     <Select
       icon={<MultiTenancyIcon />}
       className={styles.tenantPicker}
-      value={tenant ?? 'Default Tenant'}
+      value={tenant ?? 'Default tenant'}
       aria-label="Select tenant"
-      options={['Default Tenant', ...(tenants ? tenants : [])]}
+      options={['Default tenant', ...(tenants ? tenants : [])]}
       onChange={(event: ChangeEvent<HTMLSelectElement>) => {
         let selectedTenant: string = event.target.value;
-        if (selectedTenant === 'Default Tenant') {
+        if (selectedTenant === 'Default tenant') {
           selectedTenant = '';
         }
         setTenant(selectedTenant);

--- a/src/components/Auth/UsersCard/TenantPicker.tsx
+++ b/src/components/Auth/UsersCard/TenantPicker.tsx
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Select } from '@rmwc/select';
+import React, { ChangeEvent } from 'react';
+import { connect } from 'react-redux';
+import { useHistory, useParams } from 'react-router-dom';
+
+import { createStructuredSelector } from '../../../store';
+import { getTenants } from '../../../store/auth/selectors';
+import { MultiTenancyIcon } from '../../common/icons';
+import styles from './UsersCard.module.scss';
+import { authPath } from '..';
+
+export function useTenantFromUrl(): [string, (tenantId: string) => void] {
+  const history = useHistory();
+  const tenant = useParams<{ tenantId: string }>().tenantId;
+
+  function setTenant(tenantId: string) {
+    history.push(authPath + tenantId);
+  }
+
+  return [tenant, setTenant];
+}
+
+const TenantPicker: React.FC<PropsFromStore> = ({ tenants }) => {
+  const [tenant, setTenant] = useTenantFromUrl();
+
+  return (
+    <Select
+      icon={<MultiTenancyIcon />}
+      className={styles.tenantPicker}
+      value={tenant ?? 'Default Tenant'}
+      aria-label="Select tenant"
+      options={['Default Tenant', ...(tenants ? tenants : [])]}
+      onChange={(event: ChangeEvent<HTMLSelectElement>) => {
+        let selectedTenant: string = event.target.value;
+        if (selectedTenant === 'Default Tenant') {
+          selectedTenant = '';
+        }
+        setTenant(selectedTenant);
+      }}
+    />
+  );
+};
+
+export const mapStateToProps = createStructuredSelector({
+  tenants: getTenants,
+});
+
+export type PropsFromStore = ReturnType<typeof mapStateToProps>;
+
+export default connect(mapStateToProps)(TenantPicker);

--- a/src/components/Auth/UsersCard/UsersCard.module.scss
+++ b/src/components/Auth/UsersCard/UsersCard.module.scss
@@ -16,5 +16,11 @@
 
 .clearAllButton {
   text-align: end;
-  margin-bottom: 24px;
+}
+
+.tenantPicker {
+  :global select {
+    // Override global select styles to have the icons aligned properly. (same as Storage bucket picker)
+    padding: 4px 32px 0 48px !important;
+  }
 }

--- a/src/components/Auth/index.module.scss
+++ b/src/components/Auth/index.module.scss
@@ -17,3 +17,7 @@
 .sign-in-quota {
   padding: 20px;
 }
+
+.topActions {
+  margin-bottom: 24px;
+}

--- a/src/components/Auth/index.tsx
+++ b/src/components/Auth/index.tsx
@@ -44,7 +44,7 @@ export const AuthRoute: React.FC = () => {
   return (
     <Suspense fallback={<AuthRouteSuspended />}>
       <Switch>
-        <Route path={'/auth/' + `:tenantId*`}>
+        <Route path={authPath + `:tenantId*`}>
           <AuthWrapper />
         </Route>
       </Switch>
@@ -73,31 +73,27 @@ export const Auth: React.FC<AuthProps> = ({ updateAuthConfig }) => {
   }, [auth, projectId, updateAuthConfig, tenantId]);
 
   return (
-    <Switch>
-      <Route path={authPath + `:tenantId*`}>
-        <GridCell span={12} className="Auth">
-          <GridRow className={styles.topActions}>
-            <GridCell span={2}>
-              <TenantPicker />
-            </GridCell>
-            <GridCell span={8} />
-            <GridCell span={2}>
-              <ClearAll />
-            </GridCell>
-          </GridRow>
-
-          <Elevation z="2" wrap>
-            <UsersCard />
-          </Elevation>
-          <Elevation z="2" wrap>
-            <OneAccountPerEmailCard />
-          </Elevation>
-          <Elevation z="2" wrap>
-            <PassthroughModeCard />
-          </Elevation>
+    <GridCell span={12} className="Auth">
+      <GridRow className={styles.topActions}>
+        <GridCell span={2}>
+          <TenantPicker />
         </GridCell>
-      </Route>
-    </Switch>
+        <GridCell span={8} />
+        <GridCell span={2}>
+          <ClearAll />
+        </GridCell>
+      </GridRow>
+
+      <Elevation z="2" wrap>
+        <UsersCard />
+      </Elevation>
+      <Elevation z="2" wrap>
+        <OneAccountPerEmailCard />
+      </Elevation>
+      <Elevation z="2" wrap>
+        <PassthroughModeCard />
+      </Elevation>
+    </GridCell>
   );
 };
 

--- a/src/components/Auth/test_utils.ts
+++ b/src/components/Auth/test_utils.ts
@@ -27,6 +27,7 @@ export function getMockAuthStore(state?: Partial<AppState['auth']>) {
       filter: '',
       allowDuplicateEmails: false,
       usageMode: UsageMode.DEFAULT,
+      tenants: { loading: false, result: { data: [] } },
       ...state,
     },
   });
@@ -51,6 +52,7 @@ export function createFakeState(state: Partial<AuthState>): AuthState {
     allowDuplicateEmails: true,
     users: createRemoteDataLoaded([]),
     usageMode: UsageMode.DEFAULT,
+    tenants: createRemoteDataLoaded([]),
     ...state,
   };
 }

--- a/src/components/Auth/types.ts
+++ b/src/components/Auth/types.ts
@@ -115,7 +115,7 @@ export interface AuthState {
   filter: string;
   allowDuplicateEmails: boolean;
   usageMode: UsageMode;
-  tenants?: Tenant[];
+  tenants: RemoteResult<Tenant[]>;
 }
 
 // Similar the emulator config object of the same name in the Firebase CLI,

--- a/src/components/Auth/types.ts
+++ b/src/components/Auth/types.ts
@@ -99,12 +99,23 @@ export enum UsageMode {
   PASSTHROUGH = 'PASSTHROUGH',
 }
 
+export interface Tenant {
+  allowPasswordSignup: boolean;
+  disableAuth: boolean;
+  enableAnonymousUser: boolean;
+  enableEmailLinkSignin: boolean;
+  mfaConfig: { state: string; enabledProviders: string[] };
+  name: string;
+  tenantId: string;
+}
+
 export interface AuthState {
   authUserDialogData?: RemoteResult<AuthUser | undefined>;
   users: RemoteResult<AuthUser[]>;
   filter: string;
   allowDuplicateEmails: boolean;
   usageMode: UsageMode;
+  tenants?: Tenant[];
 }
 
 // Similar the emulator config object of the same name in the Firebase CLI,

--- a/src/components/common/icons.tsx
+++ b/src/components/common/icons.tsx
@@ -56,6 +56,15 @@ export const AuthIcon = svgIcon(
   </svg>
 );
 
+export const MultiTenancyIcon = svgIcon(
+  <svg viewBox="0 0 22 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M14 4C14 2.58 13.5 1.27 12.67 0.24C13.09 0.0999998 13.53 0 14 0C16.21 0 18 1.79 18 4C18 6.21 16.21 8 14 8C13.57 8 13.16 7.91 12.77 7.79C12.74 7.78 12.71 7.77 12.67 7.76C13.5 6.73 14 5.42 14 4ZM15.66 9.13C17.03 10.06 18 11.32 18 13V16H22V13C22 10.82 18.42 9.53 15.66 9.13ZM8 2C6.9 2 6 2.9 6 4C6 5.1 6.9 6 8 6C9.1 6 10 5.1 10 4C10 2.9 9.1 2 8 2ZM8 11C5.3 11 2.2 12.29 2 13.01V14H14V13C13.8 12.29 10.7 11 8 11ZM8 0C10.21 0 12 1.79 12 4C12 6.21 10.21 8 8 8C5.79 8 4 6.21 4 4C4 1.79 5.79 0 8 0ZM8 9C10.67 9 16 10.34 16 13V16H0V13C0 10.34 5.33 9 8 9Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
 export const DatabaseIcon = svgIcon(
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192">
     <g fill="none">

--- a/src/components/common/rest_api.ts
+++ b/src/components/common/rest_api.ts
@@ -34,7 +34,7 @@ export abstract class RestApi {
 
   protected async jsonRequest(
     url: string,
-    data: {},
+    data?: {},
     method: RequestMethod = 'GET',
     headers: Record<string, string> = { 'Content-Type': 'application/json' }
   ) {
@@ -42,7 +42,7 @@ export abstract class RestApi {
 
     const res = await fetch(url, {
       method,
-      body: JSON.stringify(data),
+      body: data ? JSON.stringify(data) : undefined,
       headers: {
         Authorization: 'Bearer ' + accessToken,
         ...headers,

--- a/src/store/auth/actions.tsx
+++ b/src/store/auth/actions.tsx
@@ -27,6 +27,7 @@ import { RemoteResult } from '../utils';
 export const updateAuthConfig = createAction('@auth/UPDATE_AUTH_CONFIG')<{
   projectId: string;
   auth: AuthConfig;
+  tenantId: string;
 } | null>();
 
 export const createUserRequest = createAction('@auth/CREATE_USER_REQUEST')<{
@@ -134,3 +135,11 @@ export const setAuthUserDialogError = createAction(
 export const clearAuthUserDialogData = createAction(
   '@auth/CLEAR_AUTH_USER_DIALOG_DATA'
 )();
+
+export const authFetchTenantsRequest = createAction(
+  '@auth/AUTH_FETCH_TENANTS_REQUEST'
+)();
+
+export const authFetchTenantsSuccess = createAction(
+  '@auth/AUTH_FETCH_TENANTS_SUCCESS'
+)<string[]>();

--- a/src/store/auth/reducer.test.ts
+++ b/src/store/auth/reducer.test.ts
@@ -20,7 +20,7 @@ import {
   createFakeUser,
 } from '../../components/Auth/test_utils';
 import { AuthUser } from '../../components/Auth/types';
-import { squashOrDefaut } from '../utils';
+import { squashOrDefault } from '../utils';
 import {
   authFetchUsersError,
   authFetchUsersSuccess,
@@ -100,7 +100,7 @@ describe('auth reducers', () => {
         const action = setUserDisabledSuccess({ localId, disabled: true });
 
         const result = authReducer(state, action);
-        expect(squashOrDefaut(result.users, [])[0].disabled).toEqual(true);
+        expect(squashOrDefault(result.users, [])[0].disabled).toEqual(true);
       });
 
       it(`${setUserDisabledSuccess} => enables the user`, () => {
@@ -109,7 +109,7 @@ describe('auth reducers', () => {
         const action = setUserDisabledSuccess({ localId, disabled: false });
 
         const result = authReducer(state, action);
-        expect(squashOrDefaut(result.users, [])[0].disabled).toEqual(false);
+        expect(squashOrDefault(result.users, [])[0].disabled).toEqual(false);
       });
     });
   });

--- a/src/store/auth/reducer.tsx
+++ b/src/store/auth/reducer.tsx
@@ -27,6 +27,7 @@ const INIT_STATE = {
   filter: '',
   allowDuplicateEmails: false,
   usageMode: UsageMode.DEFAULT,
+  tenants: { loading: true },
 };
 
 export const authReducer = createReducer<AuthState, Action>(INIT_STATE)
@@ -150,6 +151,17 @@ export const authReducer = createReducer<AuthState, Action>(INIT_STATE)
   .handleAction(
     authActions.authFetchTenantsSuccess,
     produce((draft: AuthState, { payload }) => {
-      draft.tenants = payload;
+      draft.tenants = {
+        loading: false,
+        result: { data: payload },
+      };
+    })
+  )
+  .handleAction(
+    authActions.authFetchTenantsRequest,
+    produce((draft: AuthState) => {
+      draft.tenants = {
+        loading: true,
+      };
     })
   );

--- a/src/store/auth/reducer.tsx
+++ b/src/store/auth/reducer.tsx
@@ -160,8 +160,8 @@ export const authReducer = createReducer<AuthState, Action>(INIT_STATE)
   .handleAction(
     authActions.authFetchTenantsRequest,
     produce((draft: AuthState) => {
-      draft.tenants = {
-        loading: true,
-      };
+      // intentionally don't wipe out the old tenants list
+      // so that components that rely on tenants list don't flicker
+      draft.tenants.loading = true;
     })
   );

--- a/src/store/auth/reducer.tsx
+++ b/src/store/auth/reducer.tsx
@@ -146,4 +146,10 @@ export const authReducer = createReducer<AuthState, Action>(INIT_STATE)
     produce((draft, { payload }) => {
       draft.usageMode = payload;
     })
+  )
+  .handleAction(
+    authActions.authFetchTenantsSuccess,
+    produce((draft: AuthState, { payload }) => {
+      draft.tenants = payload;
+    })
   );

--- a/src/store/auth/sagas.ts
+++ b/src/store/auth/sagas.ts
@@ -30,6 +30,8 @@ import {
   EmulatorV1ProjectsConfig,
 } from '../../components/Auth/types';
 import {
+  authFetchTenantsRequest,
+  authFetchTenantsSuccess,
   authFetchUsersError,
   authFetchUsersRequest,
   authFetchUsersSuccess,
@@ -66,6 +68,12 @@ export function* fetchAuthUsers(): any {
   }
 }
 
+export function* fetchTenants(): any {
+  const authApi = yield call(configureAuthSaga);
+  const tenants = yield call([authApi, 'fetchTenants']);
+  yield put(authFetchTenantsSuccess(tenants));
+}
+
 export const AUTH_API_CONTEXT = 'AUTH_API_CONTEXT';
 
 export function* initAuth({ payload }: ActionType<typeof updateAuthConfig>) {
@@ -75,11 +83,13 @@ export function* initAuth({ payload }: ActionType<typeof updateAuthConfig>) {
   yield setContext({
     [AUTH_API_CONTEXT]: new AuthApi(
       payload.auth.hostAndPort,
-      payload.projectId
+      payload.projectId,
+      payload.tenantId
     ),
   });
   yield all([
     takeLatest(getType(authFetchUsersRequest), fetchAuthUsers),
+    takeLatest(getType(authFetchTenantsRequest), fetchTenants),
     takeLatest(getType(createUserRequest), createUser),
     takeLatest(getType(nukeUsersRequest), nukeUsers),
     takeLatest(getType(deleteUserRequest), deleteUser),
@@ -96,6 +106,7 @@ export function* initAuth({ payload }: ActionType<typeof updateAuthConfig>) {
     takeLatest(getType(setUsageModeRequest), setUsageMode),
     takeLatest(getType(getUsageModeRequest), getUsageMode),
     put(authFetchUsersRequest()),
+    put(authFetchTenantsRequest()),
     put(getAllowDuplicateEmailsRequest()),
     put(getUsageModeRequest()),
   ]);

--- a/src/store/auth/selectors.ts
+++ b/src/store/auth/selectors.ts
@@ -118,3 +118,6 @@ export const getShowTable = createSelector(
   (filteredUsers, passthroughModeEnabled) =>
     !passthroughModeEnabled && filteredUsers.length > 0
 );
+export const getTenants = createSelector(getAuth, (state: AuthState) => {
+  return state.tenants?.map((tenant) => tenant.tenantId);
+});

--- a/src/store/auth/selectors.ts
+++ b/src/store/auth/selectors.ts
@@ -18,7 +18,7 @@ import { createSelector } from 'reselect';
 
 import { AuthState, AuthUser, UsageMode } from '../../components/Auth/types';
 import { AppState } from '../index';
-import { hasData, squashOrDefaut } from '../utils';
+import { hasData, squashOrDefault } from '../utils';
 
 export const getAuth = (state: AppState) => state.auth;
 
@@ -48,7 +48,7 @@ export const getAuthUsersResult = createSelector(getAuthUsers, (users) => {
 });
 
 export const getUsers = createSelector(getAuthUsers, (users) => {
-  return [...squashOrDefaut(users, [])].sort(
+  return [...squashOrDefault(users, [])].sort(
     (a, b) => Number(new Date(b.createdAt)) - Number(new Date(a.createdAt || 0))
   );
 });
@@ -119,5 +119,8 @@ export const getShowTable = createSelector(
     !passthroughModeEnabled && filteredUsers.length > 0
 );
 export const getTenants = createSelector(getAuth, (state: AuthState) => {
-  return state.tenants?.map((tenant) => tenant.tenantId);
+  return squashOrDefault(state.tenants, []).map((tenant) => tenant.tenantId);
+});
+export const getTenantsLoading = createSelector(getAuth, (state: AuthState) => {
+  return state.tenants.loading;
 });

--- a/src/store/utils.ts
+++ b/src/store/utils.ts
@@ -182,7 +182,7 @@ export function squash<T, E, R>(
   });
 }
 
-export function squashOrDefaut<T>(
+export function squashOrDefault<T>(
   remoteResult: RemoteResult<T, unknown>,
   defaultValue: T
 ) {


### PR DESCRIPTION
- Add tenant picker to Auth page (defaults to "Default tenant")
- Re-fetch users whenever tenant is changed
- If URL contains a tenant that hasn't existed before, that's ok. Emulator will auto-create the tenant

<img width="1316" alt="Screen Shot 2022-01-19 at 12 32 43 PM" src="https://user-images.githubusercontent.com/3759507/150183714-39e3b0db-ccac-471c-af7a-e44f823bf38f.png">

