### PR TITLE
Fix padding on MFA pattern error message

### DIFF
--- a/src/components/Auth/UserFormDialog/controls/controls.module.scss
+++ b/src/components/Auth/UserFormDialog/controls/controls.module.scss
@@ -123,3 +123,7 @@
   font-weight: 500;
   margin-bottom: 8px;
 }
+
+.showError {
+  padding-bottom: 16px;
+}


### PR DESCRIPTION
Adds padding to error message when input does not abide by phone number regex for MFA

Screenshot of error message no longer overlapping with "Add another" button: [go/firebase-tools-ui-691-screenshot](http://go/firebase-tools-ui-691-screenshot)
Recording of what this change looks like as phone numbers change from valid to invalid and vice versa: [go/firebase-tools-ui-691-recording](http://go/firebase-tools-ui-691-recording)

Corresponding internal bug: [b/216660095](http://b/216660095)