### PR TITLE
Set min-width for tenant picker

### DIFF
--- a/src/components/Auth/UsersCard/UsersCard.module.scss
+++ b/src/components/Auth/UsersCard/UsersCard.module.scss
@@ -23,4 +23,5 @@
     // Override global select styles to have the icons aligned properly. (same as Storage bucket picker)
     padding: 4px 32px 0 48px !important;
   }
+  min-width: 200px;
 }


### PR DESCRIPTION
Sets min-width for tenant picker. Also played around with changing the GridCell span size but at certain screen widths, the "Default tenant" text still gets clipped. Note that this change only makes it such that "Default tenant" is always fully displayed, but longer tenant names may get clipped (see recording below).

Recording of how tenant picker looks with changing screenwidth - first half of recording displays "Default tenant" text and second half displays a long tenant name: [go/firebase-tools-ui-692-tenant-picker](http://go/firebase-tools-ui-692-tenant-picker)

Corresponding internal bug: [b/216659997](http://b/216659997)