### PR TITLE
Change color of passthrough dialog button

### DIFF
--- a/src/components/Auth/PassthroughModeCard/PassthroughModeDialog.tsx
+++ b/src/components/Auth/PassthroughModeCard/PassthroughModeDialog.tsx
@@ -28,6 +28,7 @@ import { MapDispatchToPropsFunction, connect } from 'react-redux';
 import { createStructuredSelector } from '../../../store';
 import { setUsageModeRequest } from '../../../store/auth/actions';
 import { getUsageMode } from '../../../store/auth/selectors';
+import { CustomThemeProvider } from '../../../themes';
 import { Callout } from '../../common/Callout';
 import { UsageMode } from '../types';
 import styles from './PassthroughModeDialog.module.scss';
@@ -77,11 +78,16 @@ export const PassthroughModeDialog: React.FC<Props> = ({
           <DialogButton action="close" type="button" theme="secondary">
             Cancel
           </DialogButton>
-          <DialogButton type="submit" unelevated>
-            {usageMode === UsageMode.PASSTHROUGH
-              ? 'Disable passthrough'
-              : 'Enable passthrough'}
-          </DialogButton>
+          <CustomThemeProvider
+            use={usageMode === UsageMode.PASSTHROUGH ? 'tip' : 'warning'}
+            wrap
+          >
+            <DialogButton type="submit" unelevated>
+              {usageMode === UsageMode.PASSTHROUGH
+                ? 'Disable passthrough'
+                : 'Enable passthrough'}
+            </DialogButton>
+          </CustomThemeProvider>
         </DialogActions>
       </form>
     </Dialog>


### PR DESCRIPTION
Changes "Enable passthrough" button to "warning" theme. "Disable passthrough" button remains the current "tip" theme. 

Screenshot of "Enable passthrough" dialogue: [go/firebase-tools-ui-693-enable-passthrough](http://go/firebase-tools-ui-693-enable-passthrough)
Screenshot of "Disable passthrough" dialogue: [go/firebase-tools-ui-693-disable-passthrough](http://go/firebase-tools-ui-693-disable-passthrough)

Corresponding internal bug: [b/216660190](http://b/216660190)