### PR TITLE
Add padding to email error text

### DIFF
--- a/src/components/Auth/UserFormDialog/controls/Email.tsx
+++ b/src/components/Auth/UserFormDialog/controls/Email.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import classNames from 'classnames';
 import React, { useEffect } from 'react';
 import { FormContextValues } from 'react-hook-form/dist/contextTypes';
 import { connect } from 'react-redux';
@@ -71,7 +72,12 @@ const Email: React.FC<EmailProps & FormContextValues<AuthFormUser>> = ({
 
   return (
     <>
-      <div className={styles.emailWrapper}>
+      <div
+        className={classNames(
+          styles.emailWrapper,
+          getErrorText(errors) && styles.showError
+        )}
+      >
         <Field
           name="email"
           placeholder="Enter email (optional)"


### PR DESCRIPTION
Adds padding to bottom of EmailProp when error message is present. Uses the same padding as that in https://github.com/firebase/firebase-tools-ui/pull/691.

Recording of triggering/untriggering error message with padding: [go/firebase-tools-ui-694-error-text](http://go/firebase-tools-ui-694-error-text)

Corresponding internal bug: [b/216659959](http://b/216659959)