### PR TITLE
Fix auth tests

### DIFF
--- a/src/components/Auth/UserFormDialog/UserForm.tsx
+++ b/src/components/Auth/UserFormDialog/UserForm.tsx
@@ -145,7 +145,7 @@ export const UserForm: React.FC<UserFormProps> = ({
             error={errors?.displayName && 'Display name is required'}
             inputRef={register({})}
           />
-          <Email editedUserEmail={user?.email} {...form} />
+          <Email {...form} />
 
           <ImageUrlInput {...form} />
           <CustomAttributes {...form} />

--- a/src/components/Auth/UserFormDialog/controls/Email.tsx
+++ b/src/components/Auth/UserFormDialog/controls/Email.tsx
@@ -42,15 +42,13 @@ function getErrorText(errors: any) {
   }
 }
 
-export type EmailProps = PropsFromState & { editedUserEmail?: string };
-const Email: React.FC<EmailProps & FormContextValues<AuthFormUser>> = ({
+const Email: React.FC<PropsFromState & FormContextValues<AuthFormUser>> = ({
   register,
   watch,
   setError,
   clearError,
   errors,
   allEmails,
-  editedUserEmail,
 }) => {
   const email = watch('email');
 
@@ -58,7 +56,7 @@ const Email: React.FC<EmailProps & FormContextValues<AuthFormUser>> = ({
   const emailVerified = emailVerifiedArr && emailVerifiedArr.length > 0;
 
   function validate(value: string) {
-    return value === editedUserEmail || !allEmails.has(value);
+    return value === email || !allEmails.has(value);
   }
 
   useEffect(() => {

--- a/src/components/Auth/UserFormDialog/controls/EmailPassword.test.tsx
+++ b/src/components/Auth/UserFormDialog/controls/EmailPassword.test.tsx
@@ -14,59 +14,55 @@
  * limitations under the License.
  */
 
+import { fireEvent } from '@testing-library/react';
 import React from 'react';
+import { FormContextValues } from 'react-hook-form';
+import { Provider } from 'react-redux';
 
 import { wrapWithForm } from '../../../../test_utils';
-import { AddAuthUserPayload } from '../../types';
-import { EmailPassword, EmailPasswordProps } from './EmailPassword';
+import { createFakeUser, getMockAuthStore } from '../../test_utils';
+import { AddAuthUserPayload, AuthFormUser, AuthState } from '../../types';
+import Email from './Email';
+import Password from './Password';
 
 describe('EmailPassword', () => {
   const validEmail = 'pir@j.k';
 
   function setup(
     defaultValues: Partial<AddAuthUserPayload>,
-    props: EmailPasswordProps = {
-      allEmails: new Set(),
-      editedUserEmail: undefined,
-      isEditing: false,
-    }
+    state?: Partial<AuthState>
   ) {
-    return wrapWithForm(EmailPassword, { defaultValues }, props);
+    const store = getMockAuthStore(state);
+
+    return wrapWithForm(
+      (props: FormContextValues<AuthFormUser>) => (
+        <Provider store={store}>
+          <Email {...props} />
+          <Password {...props} />
+        </Provider>
+      ),
+      { defaultValues },
+      {}
+    );
   }
 
   describe('requiring both values or none', () => {
-    const errorText = 'Both email and password should be present';
+    const emailRequiredErrorText =
+      'Email is required for password authentication';
 
     it('is valid when both empty', () => {
       const { queryByText } = setup({ email: '', password: '' });
-      expect(queryByText(errorText)).toBeNull();
+      expect(queryByText(emailRequiredErrorText)).toBeNull();
     });
 
     it('is valid when both present', () => {
       const { queryByText } = setup({ email: validEmail, password: 'pelmeni' });
-      expect(queryByText(errorText)).toBeNull();
+      expect(queryByText(emailRequiredErrorText)).toBeNull();
     });
 
     it('is invalid if just password is present', () => {
       const { getByText } = setup({ email: '', password: 'pelmeni' });
-      getByText(errorText);
-    });
-
-    it('is invalid if just email is present', () => {
-      const { getByText } = setup({ email: validEmail, password: '' });
-      getByText(errorText);
-    });
-
-    it('is valid if just email is present in editing mode', () => {
-      const { queryByText } = setup(
-        { email: validEmail, password: '' },
-        {
-          allEmails: new Set(),
-          editedUserEmail: undefined,
-          isEditing: true,
-        }
-      );
-      expect(queryByText(errorText)).toBeNull();
+      expect(getByText(emailRequiredErrorText)).not.toBeNull();
     });
   });
 
@@ -88,13 +84,25 @@ describe('EmailPassword', () => {
     });
 
     it('invalid for duplicate email', async () => {
-      const { getByText, triggerValidation } = setup(
+      const { getByText, triggerValidation, getByLabelText } = setup(
         {
-          email: validEmail,
+          email: '',
           password: 'lollol',
         },
-        { allEmails: new Set([validEmail]) }
+        {
+          users: {
+            loading: false,
+            result: {
+              data: [createFakeUser({ email: validEmail })],
+            },
+          },
+        }
       );
+      const emailInput = getByLabelText('Email (optional)');
+      fireEvent.change(emailInput, {
+        target: { value: validEmail },
+      });
+
       await triggerValidation();
       expect(getByText('User with this email already exists')).not.toBeNull();
     });
@@ -105,7 +113,14 @@ describe('EmailPassword', () => {
           email: validEmail,
           password: 'lollol',
         },
-        { allEmails: new Set([validEmail]), editedUserEmail: validEmail }
+        {
+          users: {
+            loading: false,
+            result: {
+              data: [createFakeUser({ email: validEmail })],
+            },
+          },
+        }
       );
       await triggerValidation();
       expect(queryByText('User with this email already exists')).toBeNull();

--- a/src/components/Auth/UserFormDialog/controls/Password.tsx
+++ b/src/components/Auth/UserFormDialog/controls/Password.tsx
@@ -37,19 +37,9 @@ function getErrorText(errors: any) {
   }
 }
 
-export type PasswordProps = PropsFromState & { editedUserEmail?: string };
 export const Password: React.FC<
-  PasswordProps & FormContextValues<AuthFormUser>
-> = ({
-  register,
-  watch,
-  setError,
-  clearError,
-  errors,
-  allEmails,
-  editedUserEmail,
-  isEditing,
-}) => {
+  PropsFromState & FormContextValues<AuthFormUser>
+> = ({ register, watch, setError, clearError, errors, isEditing }) => {
   const email = watch('email');
   const password = watch('password');
 

--- a/src/components/Auth/UserFormDialog/controls/SignInMethod.test.tsx
+++ b/src/components/Auth/UserFormDialog/controls/SignInMethod.test.tsx
@@ -22,6 +22,7 @@ import { Provider } from 'react-redux';
 import { wrapWithForm } from '../../../../test_utils';
 import { getMockAuthStore } from '../../test_utils';
 import { AddAuthUserPayload, AuthFormUser } from '../../types';
+import Email from './Email';
 import { SignInMethod, SignInMethodProps } from './SignInMethod';
 
 describe('SignInMethod', () => {
@@ -33,6 +34,7 @@ describe('SignInMethod', () => {
     const methods = wrapWithForm(
       (props: SignInMethodProps & FormContextValues<AuthFormUser>) => (
         <Provider store={store}>
+          <Email {...props} />
           <SignInMethod {...props} />
         </Provider>
       ),
@@ -40,26 +42,26 @@ describe('SignInMethod', () => {
       { isEditing: false }
     );
 
-    const email = methods.getByLabelText('Email');
+    const password = methods.getByLabelText('Password');
 
-    fireEvent.change(email, {
+    fireEvent.change(password, {
       target: { value: 'just need to make this dirty' },
     });
 
     await methods.triggerValidation();
 
-    fireEvent.change(email, {
-      target: { value: defaultValues.email },
+    fireEvent.change(password, {
+      target: { value: defaultValues.password },
     });
 
-    fireEvent.blur(email);
+    fireEvent.blur(password);
 
     await methods.triggerValidation();
     return methods;
   }
 
   describe('requiring at least one value', () => {
-    const errorText = /One method is required./;
+    const errorText = /One method is required. Please enter either an email\/password or phone number./;
 
     it('is valid when phoneNumber present', async () => {
       const { queryByText } = await setup({
@@ -99,7 +101,6 @@ describe('SignInMethod', () => {
 
     it('shows error, if nothing is present', async () => {
       const { getByText } = await setup({
-        email: '',
         password: '',
         phoneNumber: '',
       });

--- a/src/components/Auth/UserFormDialog/controls/SignInMethod.tsx
+++ b/src/components/Auth/UserFormDialog/controls/SignInMethod.tsx
@@ -33,18 +33,18 @@ export const SignInMethod: React.FC<
   SignInMethodProps & FormContextValues<AuthFormUser>
 > = (form) => {
   const { watch, setError, clearError, formState, errors, user } = form;
-  const email = watch('email');
   const password = watch('password');
   const phoneNumber = watch('phoneNumber');
 
-  const isTouched =
-    formState.touched['email'] || formState.touched['phoneNumber'];
+  const isTouched: boolean = !!(
+    formState.touched['password'] || formState.touched['phoneNumber']
+  );
 
   useEffect(() => {
-    const hasEmail = email !== '';
+    const hasPassword = password !== '';
     const hasPhone = !!phoneNumber;
 
-    if (hasEmail || hasPhone) {
+    if (hasPassword || hasPhone) {
       // According to docs ClearError should accept arbitrary key
       // to allow cross-field validation, but it's not the case here for some
       // reason.
@@ -52,7 +52,7 @@ export const SignInMethod: React.FC<
     } else {
       setError(ERROR_AT_LEAST_ONE_METHOD_REQUIRED as any);
     }
-  }, [email, password, clearError, setError, phoneNumber, errors]);
+  }, [password, clearError, setError, phoneNumber, errors]);
 
   const isOnlyError =
     ERROR_AT_LEAST_ONE_METHOD_REQUIRED in errors &&
@@ -65,7 +65,7 @@ export const SignInMethod: React.FC<
         <Typography use="body1" theme="textPrimaryOnBackground">
           Authentication method
         </Typography>
-        {isOnlyError ? (
+        {isTouched && isOnlyError ? (
           <Typography use="body2" theme="error" tag="div" role="alert">
             One method is required. Please enter either an email/password or
             phone number.

--- a/src/components/Auth/UsersCard/table/UsersTable.test.tsx
+++ b/src/components/Auth/UsersCard/table/UsersTable.test.tsx
@@ -46,6 +46,7 @@ describe('UserTable', () => {
       shouldShowTable: true,
       shouldShowZeroResults: false,
       shouldShowZeroState: false,
+      shouldShowPassthroughMode: false,
       setUserDisabled: jest.fn(),
       openAuthUserDialog: jest.fn(),
       deleteUser: jest.fn(),

--- a/src/components/Auth/index.test.tsx
+++ b/src/components/Auth/index.test.tsx
@@ -16,8 +16,10 @@
 
 import { RMWCProvider } from '@rmwc/provider';
 import { render } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
 import React from 'react';
 import { Provider } from 'react-redux';
+import { Router } from 'react-router-dom';
 
 import { AuthConfig } from '../../store/config';
 import { TestEmulatorConfigProvider } from '../common/EmulatorConfigProvider';
@@ -34,10 +36,14 @@ const sampleConfig: AuthConfig = {
 
 describe('AuthRoute', () => {
   it('renders loading when config is not ready', () => {
+    const history = createMemoryHistory({ initialEntries: ['/auth'] });
+
     const { getByText } = render(
       <TestEmulatorConfigProvider config={undefined}>
         <Provider store={getMockAuthStore()}>
-          <AuthRoute />
+          <Router history={history}>
+            <AuthRoute />
+          </Router>
         </Provider>
       </TestEmulatorConfigProvider>
     );
@@ -45,10 +51,14 @@ describe('AuthRoute', () => {
   });
 
   it('renders error when loading config fails', () => {
+    const history = createMemoryHistory({ initialEntries: ['/auth'] });
+
     const { getByText } = render(
       <TestEmulatorConfigProvider config={null}>
         <Provider store={getMockAuthStore()}>
-          <AuthRoute />
+          <Router history={history}>
+            <AuthRoute />
+          </Router>
         </Provider>
       </TestEmulatorConfigProvider>
     );
@@ -56,12 +66,16 @@ describe('AuthRoute', () => {
   });
 
   it('renders error when auth emulator is not running', () => {
+    const history = createMemoryHistory({ initialEntries: ['/auth'] });
+
     const { getByText } = render(
       <TestEmulatorConfigProvider
         config={{ projectId: 'example' /* no auth */ }}
       >
         <Provider store={getMockAuthStore()}>
-          <AuthRoute />
+          <Router history={history}>
+            <AuthRoute />
+          </Router>
         </Provider>
       </TestEmulatorConfigProvider>
     );
@@ -69,6 +83,8 @@ describe('AuthRoute', () => {
   });
 
   it('displays auth', async () => {
+    const history = createMemoryHistory({ initialEntries: ['/auth'] });
+
     const store = getMockAuthStore();
 
     const { getByText } = render(
@@ -81,7 +97,9 @@ describe('AuthRoute', () => {
               auth: sampleConfig,
             }}
           >
-            <AuthRoute />
+            <Router history={history}>
+              <AuthRoute />
+            </Router>
           </TestEmulatorConfigProvider>
         </RMWCProvider>
       </Provider>


### PR DESCRIPTION
Get the existing Auth tests to pass given the changes in `auth-new-features`. Biggest behavior change was around email+password validation, since now it's possible to have an email without a password.