### PR TITLE
Fix storage emulator tests

### DIFF
--- a/src/components/Storage/Card/Table/Header/StorageHeader/CreateFolder/CreateFolder.test.tsx
+++ b/src/components/Storage/Card/Table/Header/StorageHeader/CreateFolder/CreateFolder.test.tsx
@@ -25,7 +25,7 @@ import { renderWithStorage } from '../../../../../testing/renderWithStorage';
 import { CreateFolder } from './CreateFolder';
 
 describe('CreateFolder', () => {
-  it.skip('opens folder dialog and then creates folder', async () => {
+  it('opens folder dialog and then creates folder', async () => {
     const {
       getByLabelText,
       getByText,

--- a/src/components/Storage/Card/Table/Header/StorageHeader/CreateFolder/CreateFolder.test.tsx
+++ b/src/components/Storage/Card/Table/Header/StorageHeader/CreateFolder/CreateFolder.test.tsx
@@ -25,7 +25,7 @@ import { renderWithStorage } from '../../../../../testing/renderWithStorage';
 import { CreateFolder } from './CreateFolder';
 
 describe('CreateFolder', () => {
-  it('opens folder dialog and then creates folder', async () => {
+  it.skip('opens folder dialog and then creates folder', async () => {
     const {
       getByLabelText,
       getByText,

--- a/src/components/Storage/api/useCreateFolder.tsx
+++ b/src/components/Storage/api/useCreateFolder.tsx
@@ -17,14 +17,15 @@
 import { useEmulatorConfig } from '../../common/EmulatorConfigProvider';
 import { useBucket } from './useBucket';
 
-const EMPTY_FOLDER_DATA = `--boundary
-Content-Type: application/json
-
-{"contentType":"text/plain"}
---boundary
-Content-Type: text/plain
-
---boundary--`;
+const EMPTY_FOLDER_DATA = `--boundary\r
+Content-Type: application/json\r
+\r
+{"contentType":"text/plain"}\r
+--boundary\r
+Content-Type: text/plain\r
+\r
+--boundary--\r
+`;
 
 export function useCreateFolder() {
   const config = useEmulatorConfig('storage');

--- a/src/components/Storage/api/useStorageFiles.test.tsx
+++ b/src/components/Storage/api/useStorageFiles.test.tsx
@@ -78,7 +78,7 @@ describe('useStorageFiles', () => {
       expect.objectContaining({
         type: 'folder',
         name: folderName,
-        fullPath: '/' + folderName,
+        fullPath: folderName,
       })
     );
 
@@ -112,7 +112,7 @@ describe('useStorageFiles', () => {
     await uploadFile('other.file', folderName);
 
     await act(async () => {
-      await deleteFiles(['/' + folderName, fileName]);
+      await deleteFiles([folderName, fileName]);
     });
 
     await waitForNFiles(1);


### PR DESCRIPTION
Since https://github.com/firebase/firebase-tools/pull/3647 was merged, the list endpoint now exhibits different (more correct) behavior than what the integration tests in this repo was testing against. This PR fixes the assertions in the integration tests to match the new live version of the storage
 emulator.

Note: https://github.com/firebase/firebase-tools/pull/3647 introduces a new visual bug in the emulator wherein zero-byte files that denote empty folders are now shown in the file browser. 

<img width="1025" alt="Screen Shot 2022-03-16 at 9 20 21 PM" src="https://user-images.githubusercontent.com/1237337/158717764-86a9a32f-9992-4a9e-9469-e921a8e05b35.png">

The behavior of the storage emulator is correct in this case, but the view logic of the UI needs to filter out these files before rendering. Files https://github.com/firebase/firebase-tools-ui/issues/728 to track.