### PR TITLE
Show `queryFieldValue` when the `collectionFilter` is valid

### DIFF
--- a/src/components/Firestore/Collection.tsx
+++ b/src/components/Firestore/Collection.tsx
@@ -235,9 +235,7 @@ export const CollectionPresentation: React.FC<CollectionPresentationProps> = ({
           dense
           className="Firestore-Document-List"
           tag="div"
-          twoLine={
-            collectionFilter && isSortableCollectionFilter(collectionFilter)
-          }
+          twoLine={collectionFilter?.operator}
         >
           {docs.map((doc) => (
             <DocumentListItem
@@ -245,7 +243,7 @@ export const CollectionPresentation: React.FC<CollectionPresentationProps> = ({
               url={url}
               docId={doc.ref.id}
               queryFieldValue={
-                collectionFilter && isSortableCollectionFilter(collectionFilter)
+                collectionFilter?.operator
                   ? get(doc.data(), collectionFilter.field)
                   : undefined
               }


### PR DESCRIPTION
I referred to the Firebase Console UI.

## Before
<img width="484" alt="before" src="https://user-images.githubusercontent.com/2603644/159113464-d6c8bda6-a631-44c0-b623-c876e2b3d300.png">

## After
<img width="482" alt="after" src="https://user-images.githubusercontent.com/2603644/159113467-6501bbfc-5fd4-4b08-9902-01c5d482bd97.png">

