### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/components/Database/DataViewer/ValueDisplay.tsx
+++ b/src/components/Database/DataViewer/ValueDisplay.tsx
@@ -31,7 +31,7 @@ export const ValueDisplay = React.memo<Props>(function ValueDisplay$({
 }) {
   const trimmedValue =
     typeof value === 'string' && value.length >= 24
-      ? `${value.substr(0, 21)}...`
+      ? `${value.slice(0, 21)}...`
       : value;
 
   const getClass = (value: Props['value']) =>

--- a/src/components/Database/Database.tsx
+++ b/src/components/Database/Database.tsx
@@ -72,7 +72,7 @@ export const Database: React.FC<Props> = ({ config, namespace, path }) => {
   const urlBase = `/database/${namespace}/data`;
   const handleNavigate = (newPath: string) => {
     if (newPath.startsWith('/')) {
-      newPath = newPath.substr(1);
+      newPath = newPath.slice(1);
     }
     history.push(`${urlBase}/${newPath}`);
   };

--- a/src/components/Firestore/Requests/RequestPath/index.tsx
+++ b/src/components/Firestore/Requests/RequestPath/index.tsx
@@ -86,7 +86,7 @@ function truncateRequestPathFromLeft(
   // the space of the '...' characters ('...' replaces the first 3 characters of the truncated path)
   const newTruncatedPathString =
     newPathStart > 0
-      ? `...${fullRequestPath.substr(newPathStart + 3)}`
+      ? `...${fullRequestPath.slice(newPathStart + 3)}`
       : fullRequestPath;
   // Only update the HTMLElement's inner-text if the string value changed
   // after truncation (to avoid unnecessary rerenders of component)

--- a/src/components/Firestore/utils.ts
+++ b/src/components/Firestore/utils.ts
@@ -156,7 +156,7 @@ export function summarize(data: FirestoreAny, maxLen: number): string {
     case FieldType.BLOB:
       const base64 = (data as firebase.firestore.Blob).toBase64();
       if (base64.length < maxLen) return base64;
-      else return base64.substr(0, maxLen) + '...';
+      else return base64.slice(0, maxLen) + '...';
     case FieldType.BOOLEAN:
       return (data as boolean).toString();
     case FieldType.GEOPOINT:

--- a/src/components/common/BreadCrumbs.tsx
+++ b/src/components/common/BreadCrumbs.tsx
@@ -40,7 +40,7 @@ export const BreadCrumbs: React.FC<Props> = ({
   children,
   homeElement = <IconButton icon={'home'} />,
 }) => {
-  const normalizedPath = path.startsWith('/') ? path.substr(1) : path;
+  const normalizedPath = path.startsWith('/') ? path.slice(1) : path;
   const keys = normalizedPath ? normalizedPath.split('/') : EMPTY_KEYS;
 
   const hrefs = keys.reduce<string[]>((acc, key) => {

--- a/src/components/common/InteractiveBreadCrumbBar.tsx
+++ b/src/components/common/InteractiveBreadCrumbBar.tsx
@@ -53,7 +53,7 @@ export const InteractiveBreadCrumbBar: React.FC<Props> = ({
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
-    const normalizedPath = value.startsWith('/') ? value.substr(1) : value;
+    const normalizedPath = value.startsWith('/') ? value.slice(1) : value;
     onNavigate(normalizedPath);
     setIsEditing(false);
   };


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.