### PR TITLE
Scroll for long ids in PanelHeader

### DIFF
--- a/src/components/Firestore/PanelHeader.scss
+++ b/src/components/Firestore/PanelHeader.scss
@@ -28,4 +28,5 @@
 
 .Firestore-PanelHeader-title {
   padding-left: 4px;
+  overflow-x: scroll;
 }


### PR DESCRIPTION
Fixing a small layout bug in `PanelHeader` where long ids cause the layout to overflow past their containers.

### Before
<img width="1308" alt="overflow-bug" src="https://user-images.githubusercontent.com/4570265/168818922-b40ae208-2af4-4636-8e9f-ad86601d3abd.png">

### After
<img width="1278" alt="overflow-fix" src="https://user-images.githubusercontent.com/4570265/168818962-58884ae4-68ec-4964-a9a5-f04b9ca6fb88.png">

