### PR TITLE
Set legacy ipv4first for dns resolution

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -63,7 +63,7 @@ jobs:
         # forceExit: something is not cleaning up - likely firebase-app that needs to be deleted, investigate
         run: |
           npm install -g firebase-tools@latest
-          firebase emulators:exec --only database,firestore,storage --project sample 'npm run test:coverage -- --forceExit --logHeapUsage'
+          firebase emulators:exec --only database,firestore,storage --project sample 'npm run test:coverage -- --forceExit'
         env:
           CI: true
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -63,7 +63,7 @@ jobs:
         # forceExit: something is not cleaning up - likely firebase-app that needs to be deleted, investigate
         run: |
           npm install -g firebase-tools@latest
-          firebase emulators:exec --only database,firestore,storage --project sample 'npm run test:coverage -- --forceExit'
+          firebase emulators:exec --only database,firestore,storage --project sample 'npm run test:coverage -- --forceExit --logHeapUsage'
         env:
           CI: true
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -45,6 +45,9 @@ jobs:
   unit:
     runs-on: ubuntu-latest
 
+    env:
+      NODE_OPTIONS: '--max_old_space_size=4096'
+
     strategy:
       matrix:
         node-version: [14.x, 16.x, 18.x]

--- a/custom-jest-environment.js
+++ b/custom-jest-environment.js
@@ -18,6 +18,9 @@
 // This file is used in `npm test` to override a few globals on top of jsdom.
 
 const JsdomEnvironment = require('jest-environment-jsdom');
+const dns = require('dns');
+
+dns.setDefaultResultOrder('ipv4first');
 
 class EmulatorUiTestEnvironment extends JsdomEnvironment {
   constructor(config) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "@types/codemirror": "^5.60.1",
         "@types/jest": "^26.0.0",
         "@types/lodash.debounce": "^4.0.6",
-        "@types/node": "^13.9.3",
         "@types/react": "^18.0.9",
         "@types/react-dom": "^18.0.3",
         "@types/recompose": "^0.30.7",
@@ -79,6 +78,7 @@
         "@testing-library/react": "^13.2.0",
         "@types/lodash.get": "^4.4.6",
         "@types/lodash.isequal": "^4.5.5",
+        "@types/node": "^14.18.18",
         "@types/react-router": "^5.1.18",
         "@types/react-router-dom": "^5.3.0",
         "@types/redux-mock-store": "^1.0.2",
@@ -101,7 +101,7 @@
         "webpack-cli": "^4.9.2"
       },
       "engines": {
-        "node": ">= 14.0.0"
+        "node": "^14.18.0 || >=16.4.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5342,9 +5342,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
-      "version": "13.13.52",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-      "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
+      "version": "14.18.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.18.tgz",
+      "integrity": "sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -24011,9 +24011,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "@types/node": {
-      "version": "13.13.52",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-      "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
+      "version": "14.18.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.18.tgz",
+      "integrity": "sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig=="
     },
     "@types/parse-json": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "build:server": "webpack --target=node ./server.js -o server.bundle.js",
     "test": "react-scripts test --env=./custom-jest-environment.js",
     "test:debug": "react-scripts --inspect-brk test --env=./custom-jest-environment.js --runInBand",
-    "test:coverage": "node --expose-gc --max-old-space-size=4076 node_modules/.bin/react-scripts test --coverage --watchAll=false --env=./custom-jest-environment.js --logHeapUsage --runInBand",
+    "test:coverage": "react-scripts --expose-gc test --coverage --watchAll=false --env=./custom-jest-environment.js",
     "eject": "react-scripts eject",
     "lint": "prettier --check . && eslint 'src/**/*.{ts,tsx}'",
     "lint:fix": "eslint --fix 'src/**/*.{ts,tsx}' && npm run format",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "build:server": "webpack --target=node ./server.js -o server.bundle.js",
     "test": "react-scripts test --env=./custom-jest-environment.js",
     "test:debug": "react-scripts --inspect-brk test --env=./custom-jest-environment.js --runInBand",
-    "test:coverage": "react-scripts test --coverage --watchAll=false --env=./custom-jest-environment.js",
+    "test:coverage": "node --expose-gc node_modules/.bin/react-scripts test --coverage --watchAll=false --env=./custom-jest-environment.js --logHeapUsage",
     "eject": "react-scripts eject",
     "lint": "prettier --check . && eslint 'src/**/*.{ts,tsx}'",
     "lint:fix": "eslint --fix 'src/**/*.{ts,tsx}' && npm run format",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "build:server": "webpack --target=node ./server.js -o server.bundle.js",
     "test": "react-scripts test --env=./custom-jest-environment.js",
     "test:debug": "react-scripts --inspect-brk test --env=./custom-jest-environment.js --runInBand",
-    "test:coverage": "react-scripts --expose-gc test --coverage --watchAll=false --env=./custom-jest-environment.js",
+    "test:coverage": "react-scripts test --coverage --watchAll=false --env=./custom-jest-environment.js",
     "eject": "react-scripts eject",
     "lint": "prettier --check . && eslint 'src/**/*.{ts,tsx}'",
     "lint:fix": "eslint --fix 'src/**/*.{ts,tsx}' && npm run format",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "build:server": "webpack --target=node ./server.js -o server.bundle.js",
     "test": "react-scripts test --env=./custom-jest-environment.js",
     "test:debug": "react-scripts --inspect-brk test --env=./custom-jest-environment.js --runInBand",
-    "test:coverage": "node --expose-gc node_modules/.bin/react-scripts test --coverage --watchAll=false --env=./custom-jest-environment.js --logHeapUsage --runInBand",
+    "test:coverage": "node --expose-gc --max-old-space-size=4076 node_modules/.bin/react-scripts test --coverage --watchAll=false --env=./custom-jest-environment.js --logHeapUsage --runInBand",
     "eject": "react-scripts eject",
     "lint": "prettier --check . && eslint 'src/**/*.{ts,tsx}'",
     "lint:fix": "eslint --fix 'src/**/*.{ts,tsx}' && npm run format",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.7.0",
   "private": true,
   "engines": {
-    "node": ">= 14.0.0"
+    "node": "^14.18.0 || >=16.4.0"
   },
   "dependencies": {
     "@rehooks/local-storage": "^2.3.0",
@@ -36,7 +36,6 @@
     "@types/codemirror": "^5.60.1",
     "@types/jest": "^26.0.0",
     "@types/lodash.debounce": "^4.0.6",
-    "@types/node": "^13.9.3",
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.3",
     "@types/recompose": "^0.30.7",
@@ -119,6 +118,7 @@
     "@testing-library/react": "^13.2.0",
     "@types/lodash.get": "^4.4.6",
     "@types/lodash.isequal": "^4.5.5",
+    "@types/node": "^14.18.18",
     "@types/react-router": "^5.1.18",
     "@types/react-router-dom": "^5.3.0",
     "@types/redux-mock-store": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "build:server": "webpack --target=node ./server.js -o server.bundle.js",
     "test": "react-scripts test --env=./custom-jest-environment.js",
     "test:debug": "react-scripts --inspect-brk test --env=./custom-jest-environment.js --runInBand",
-    "test:coverage": "node --expose-gc node_modules/.bin/react-scripts test --coverage --watchAll=false --env=./custom-jest-environment.js --logHeapUsage",
+    "test:coverage": "node --expose-gc node_modules/.bin/react-scripts test --coverage --watchAll=false --env=./custom-jest-environment.js --logHeapUsage --runInBand",
     "eject": "react-scripts eject",
     "lint": "prettier --check . && eslint 'src/**/*.{ts,tsx}'",
     "lint:fix": "eslint --fix 'src/**/*.{ts,tsx}' && npm run format",

--- a/server.js
+++ b/server.js
@@ -23,7 +23,10 @@
 const express = require('express');
 const fetch = require('node-fetch').default;
 const path = require('path');
+const dns = require('dns');
 const { URL } = require('url');
+
+dns.setDefaultResultOrder('ipv4first');
 
 /**
   Start an express app that serves both static content and APIs.


### PR DESCRIPTION
Bumps heap size for our tests where they were skirting a 2gb limit and crashing.