### PR TITLE
Quick fix for storage-sdk

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Create a report to help us improve
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 Note: Before filing bugs in this repo, please ensure that this is a bug for the Emulator Suite UI. Emulator Suite and/or Firebase CLI bugs should be filed under the firebase-tools repo here:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,6 @@ about: Suggest an idea for this project
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 Note: Before filing feature requests in this repo, please ensure that this is a feature request for the Emulator Suite UI. Emulator Suite and/or Firebase CLI feature requests should be filed under the firebase-tools repo here:

--- a/src/components/Storage/Card/SideBar/StoragePreview/usePreviewUrl.ts
+++ b/src/components/Storage/Card/SideBar/StoragePreview/usePreviewUrl.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { getDownloadURL, ref } from 'firebase/storage';
 import { useStorage } from 'reactfire';
 import useSWR from 'swr';
 
@@ -49,7 +50,7 @@ export const usePreviewUrl = (file: StorageFile) => {
       if (!shouldShowPreview(file.contentType)) {
         return Promise.resolve(undefined);
       }
-      return storage.refFromURL(getLocation(file.fullPath)).getDownloadURL();
+      return getDownloadURL(ref(storage, getLocation(file.fullPath)));
     },
     { suspense: true }
   );


### PR DESCRIPTION
Doesn't look like this file has tests, but if I recall storage
testing is still borked w/ js-dom