### PR TITLE
Fix websocket host logic.

### DIFF
--- a/src/components/common/EmulatorConfigProvider.tsx
+++ b/src/components/common/EmulatorConfigProvider.tsx
@@ -247,15 +247,9 @@ async function configFetcher(url: string): Promise<Config> {
     };
   }
 
-  if (result.firestore?.webSocketHost) {
-    if (result.firestore.webSocketHost === result.firestore.host) {
-      console.warn(
-        `Firestore WebSocket listens on different host ${result.firestore.webSocketHost} than Firestore (${result.firestore.host}). Requests monitor may not work.`
-      );
-    } else {
-      // Apply the same `host` change above to the WebSocket server.
-      result.firestore.webSocketHost = result.firestore.host;
-    }
+  if (result.firestore?.webSocketPort) {
+    // Apply the same `host` change above to the WebSocket server.
+    result.firestore.webSocketHost = result.firestore.host;
   }
   return result;
 }


### PR DESCRIPTION
The previous code incorrectly issues warnings when the hosts match and did not apply on the fix. The new logic will effectively ignore the `webSocketHost` field -- a different configuration isn't supported by the CLI anyway.