### PR TITLE
Navigate to Overview when clicking AppBar logo or title

### DIFF
--- a/src/components/App/AppBar.scss
+++ b/src/components/App/AppBar.scss
@@ -40,6 +40,8 @@
     left: -32px;
     min-width: 0;
     position: relative;
+    text-decoration: none;
+    color: unset;
   }
 
   .Logo {

--- a/src/components/App/AppBar.tsx
+++ b/src/components/App/AppBar.tsx
@@ -66,12 +66,12 @@ export const AppBar: React.FC<React.PropsWithChildren<Props>> = ({
     >
       <TopAppBar fixed className="AppBar" theme="surface">
         <div className="AppBar-title-row">
-          <div className="AppBar-logo-lockup">
+          <Link to="/" className="AppBar-logo-lockup">
             <Logo />
             <Typography use="headline5" className="AppBar-title" tag="h1">
               Firebase Emulator Suite
             </Typography>
-          </div>
+          </Link>
         </div>
         <TabBar theme="onSurface" activeTabIndex={activeTabIndex}>
           {tabs}


### PR DESCRIPTION
Added a <Link> to the AppBar, to allow users to navigate to Overview, by clicking either the AppBar logo or title.

(Had to add a couple of style overwrites for the default hyperlink styling on the generated <a> tag.)