### PR TITLE
fix(a11y) Add labels on navigation links

### DIFF
--- a/src/components/Home/index.test.tsx
+++ b/src/components/Home/index.test.tsx
@@ -63,7 +63,7 @@ it('shows port for emulator that are loaded and N/A for not loaded', () => {
   // Database Emulator is running.
   const databaseCard = getByTestId(`emulator-info-database`);
   expect(getByText(databaseCard, '9000')).not.toBeNull();
-  expect(getByText(databaseCard, 'Go to emulator')).not.toBeNull();
+  expect(getByText(databaseCard, 'Go to database emulator')).not.toBeNull();
 
   // Firestore Emulator is not running.
   const firestoreCard = getByTestId(`emulator-info-firestore`);

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -75,12 +75,14 @@ const Overview: React.FC<
           icon={<AuthIcon theme="secondary" />}
           config={config.auth}
           linkTo="/auth"
+          linkLabel="Go to auth emulator"
           testId="emulator-info-auth"
         />
         <EmulatorCard
           name="Firestore emulator"
           icon={<FirestoreIcon theme="secondary" />}
           config={config.firestore}
+          linkLabel="Go to firestore emulator"
           linkTo="/firestore"
           testId="emulator-info-firestore"
         />
@@ -89,6 +91,7 @@ const Overview: React.FC<
           icon={<DatabaseIcon theme="secondary" />}
           config={config.database}
           linkTo="/database"
+          linkLabel="Go to database emulator"
           testId="emulator-info-database"
         />
         <EmulatorCard
@@ -126,6 +129,7 @@ const Overview: React.FC<
           icon={<ExtensionsIcon theme="secondary" />}
           config={config.extensions}
           linkTo="/extensions"
+          linkLabel="Go to extensions emulator"
           testId="emulator-info-extensions"
         />
       </GridRow>


### PR DESCRIPTION
This commit adds labels for several of the EmulatorCards on the homepage.

https://screenshot.googleplex.com/5ZyTus5LZwjgTWi

FIXED=259424844