### PR TITLE
fix(a11y) Fix Status a11y bug for EmulatorCard

### DIFF
--- a/src/components/Home/StatusLabel.tsx
+++ b/src/components/Home/StatusLabel.tsx
@@ -48,6 +48,7 @@ export const StatusLabel: React.FC<
       >
         {isActive ? 'On' : 'Off'}
         <Icon
+          aria-hidden="true"
           icon={isActive ? ACTIVE_ICON : INACTIVE_ICON}
           className={styles.icon}
         />


### PR DESCRIPTION
This commit fixes an issue where the icon name of the "block" and "green check" labels were being announced.

This is confusing and not helpful to the end user, as there is descriptive text announcing the status of the Emulator Card.

Fixes:
b/259425107

Tested on Chrome Screen Reader