### PR TITLE
fix(a11y) Add aria-labels for doc and collection links

### DIFF
--- a/src/components/Firestore/CollectionList.tsx
+++ b/src/components/Firestore/CollectionList.tsx
@@ -152,7 +152,7 @@ export const CollectionListItem: React.FC<
       className="Firestore-List-Item"
       tag={NavLink}
       to={`${routeMatchUrl}/${encodeURIComponent(collectionId)}`}
-      aria-label={`Collection with id "${collectionId}"`}
+      aria-label={`View contents of collection with id: "${collectionId}"`}
       activeClassName="mdc-list-item--activated"
       data-testid="firestore-collection-list-item"
     >

--- a/src/components/Firestore/CollectionList.tsx
+++ b/src/components/Firestore/CollectionList.tsx
@@ -152,6 +152,7 @@ export const CollectionListItem: React.FC<
       className="Firestore-List-Item"
       tag={NavLink}
       to={`${routeMatchUrl}/${encodeURIComponent(collectionId)}`}
+      aria-label={`Collection with id "${collectionId}"`}
       activeClassName="mdc-list-item--activated"
       data-testid="firestore-collection-list-item"
     >

--- a/src/components/Firestore/DocumentListItem.tsx
+++ b/src/components/Firestore/DocumentListItem.tsx
@@ -43,6 +43,8 @@ const DocumentListItem: React.FC<
     [styles.missing]: missing,
   });
 
+  const encodedDocId = encodeURIComponent(docId);
+
   return (
     <Theme
       use={[missing ? 'textSecondaryOnBackground' : 'textPrimaryOnBackground']}
@@ -50,7 +52,8 @@ const DocumentListItem: React.FC<
       <ListItem
         className={listItemClass}
         tag={NavLink}
-        to={`${url}/${encodeURIComponent(docId)}`}
+        to={`${url}/${encodedDocId}`}
+        aria-label={`Document: ${encodedDocId}`}
         activeClassName="mdc-list-item--activated"
         data-testid="firestore-document-list-item"
       >

--- a/src/components/Firestore/DocumentListItem.tsx
+++ b/src/components/Firestore/DocumentListItem.tsx
@@ -53,7 +53,7 @@ const DocumentListItem: React.FC<
         className={listItemClass}
         tag={NavLink}
         to={`${url}/${encodedDocId}`}
-        aria-label={`Document: ${encodedDocId}`}
+        aria-label={`View contents of document with id: ${encodedDocId}`}
         activeClassName="mdc-list-item--activated"
         data-testid="firestore-document-list-item"
       >


### PR DESCRIPTION
This commit adds aria-labels for the doc and collection links. With this screen readers will read out "Collection: something" instead of just "something", providing more of a hint on what they are clicking on.

FIXED=b/259448076
b/259448076