### PR TITLE
fix(a11y) Fix double-focus upload-button issue

### DIFF
--- a/src/components/Storage/Card/Table/Header/StorageHeader/UploadButton/UploadButton.tsx
+++ b/src/components/Storage/Card/Table/Header/StorageHeader/UploadButton/UploadButton.tsx
@@ -31,7 +31,7 @@ export const UploadButton: React.FC<React.PropsWithChildren<unknown>> = () => {
   });
 
   return (
-    <div className={styles.uploadButton} {...getRootProps()}>
+    <div className={styles.uploadButton} {...getRootProps({tabIndex: -1})}>
       <Button unelevated>Upload file</Button>
       <input aria-label="Upload" {...getInputProps()} />
     </div>

--- a/src/components/Storage/Card/Table/Header/StorageHeader/UploadButton/UploadButton.tsx
+++ b/src/components/Storage/Card/Table/Header/StorageHeader/UploadButton/UploadButton.tsx
@@ -31,7 +31,7 @@ export const UploadButton: React.FC<React.PropsWithChildren<unknown>> = () => {
   });
 
   return (
-    <div className={styles.uploadButton} {...getRootProps({tabIndex: -1})}>
+    <div className={styles.uploadButton} {...getRootProps({ tabIndex: -1 })}>
       <Button unelevated>Upload file</Button>
       <input aria-label="Upload" {...getInputProps()} />
     </div>


### PR DESCRIPTION
This commit fixes an issue where the "Upload File" section of the Storage page contained 2 click targets.

It turns out the 2 click targets were the div wrapper and the button itself.

For a11y, we want the focus target to be on the button instead of the div (the screen reader will announce the user is focused on a button when reading out the aria-label.)

FIXED=259449474, b/259449474
b/259449474