### PR TITLE
fix(a11y) Stop storage row icon screen reader announcement

### DIFF
--- a/src/components/Storage/common/StorageFileIcon/StorageFileIcon.tsx
+++ b/src/components/Storage/common/StorageFileIcon/StorageFileIcon.tsx
@@ -90,7 +90,7 @@ export const StorageFileIcon: React.FC<
 > = ({ contentType }) => {
   return (
     <Theme use="secondary">
-      <Icon icon={getFileIcon(contentType)} className={styles.icon} />
+      <Icon aria-hidden="true" icon={getFileIcon(contentType)} className={styles.icon} />
     </Theme>
   );
 };

--- a/src/components/Storage/common/StorageFileIcon/StorageFileIcon.tsx
+++ b/src/components/Storage/common/StorageFileIcon/StorageFileIcon.tsx
@@ -90,7 +90,11 @@ export const StorageFileIcon: React.FC<
 > = ({ contentType }) => {
   return (
     <Theme use="secondary">
-      <Icon aria-hidden="true" icon={getFileIcon(contentType)} className={styles.icon} />
+      <Icon
+        aria-hidden="true"
+        icon={getFileIcon(contentType)}
+        className={styles.icon}
+      />
     </Theme>
   );
 };


### PR DESCRIPTION
This commit stops the screen reader from announcing the icon of the StorageFile row, as that does not give the end-user enough description.

There is a possible follow up of adding something like:

"*Image* file titled *filename.png*"

But the actual text requires discussion.

FIXED=259449521, b/259449521
b/259449521