### PR TITLE
fix(a11y) Show focus/hover shadow/ipple effect on BreadCrumb Buttons

### DIFF
--- a/src/components/common/BreadCrumbs.scss
+++ b/src/components/common/BreadCrumbs.scss
@@ -34,11 +34,6 @@
   @include a11y-display-on-hover('.BreadCrumbs-edit .mdc-icon-button');
 
   .mdc-icon-button {
-    &::before,
-    &::after {
-      display: none; // remove the hover/ripple
-    }
-
     &:hover {
       color: var(--mdc-theme-text-primary-on-background);
     }


### PR DESCRIPTION
This commit adds back the ripple effect for buttons within the Breadcrumb area.

This fixes the issue where the "Import JSON" button was not accessible. In truth, the button was always accessible, but without the ripple/shadow the user doesn't know they are focused on the button.

FIXED=259452701, b/259452701
b/259452701