### PR TITLE
fix(a11y) Add "enter" ability for logs page

### DIFF
--- a/src/components/LogViewer/QueryBar.scss
+++ b/src/components/LogViewer/QueryBar.scss
@@ -48,7 +48,6 @@
     background-color: rgba(0, 0, 0, 0);
     caret-color: black;
     color: rgba(0, 0, 0, 0);
-    padding-top: 0;
 
     &:focus {
       outline: none;

--- a/src/components/LogViewer/QueryBar.scss
+++ b/src/components/LogViewer/QueryBar.scss
@@ -48,6 +48,7 @@
     background-color: rgba(0, 0, 0, 0);
     caret-color: black;
     color: rgba(0, 0, 0, 0);
+    padding-top: 0;
 
     &:focus {
       outline: none;

--- a/src/components/LogViewer/QueryBar.tsx
+++ b/src/components/LogViewer/QueryBar.tsx
@@ -212,18 +212,19 @@ export const QueryBar: React.FC<React.PropsWithChildren<Props>> = ({
   return (
     <div className="QueryBar">
       <div className="QueryBar-render">{parsedQuery.elements}</div>
-      <input
+      <textarea
+        rows={1}
         className="QueryBar-input"
         spellCheck={false}
         value={temporaryQuery}
         onChange={(e) => setTemporaryQuery((e.target as any).value)}
         onKeyUp={(ev) => {
-          if (ev?.key === 'Enter') {
+          if (ev?.key === 'Enter' && !ev.shiftKey) {
             setQuery(temporaryQuery);
           }
         }}
         placeholder="Filter or search logs..."
-      />
+      ></textarea>
       <div className="QueryBar-actions">
         <Button
           unelevated

--- a/src/components/LogViewer/QueryBar.tsx
+++ b/src/components/LogViewer/QueryBar.tsx
@@ -212,14 +212,18 @@ export const QueryBar: React.FC<React.PropsWithChildren<Props>> = ({
   return (
     <div className="QueryBar">
       <div className="QueryBar-render">{parsedQuery.elements}</div>
-      <textarea
-        rows={1}
+      <input
         className="QueryBar-input"
         spellCheck={false}
         value={temporaryQuery}
         onChange={(e) => setTemporaryQuery((e.target as any).value)}
+        onKeyUp={(ev) => {
+          if (ev?.key === 'Enter') {
+            setQuery(temporaryQuery);
+          }
+        }}
         placeholder="Filter or search logs..."
-      ></textarea>
+      />
       <div className="QueryBar-actions">
         <Button
           unelevated


### PR DESCRIPTION
This commit updates the log query textarea into an input and adds the "Enter" functionality."

The "input" part is almost unncessary, since we could have accomplished the behavior by just adding the "onKeyUp", but then we are conveying a wrong message to screen reader users based on the element we are using.

FIXED=259450050, b/259450050
b/259450050