### PR TITLE
fix(a11y) Add better labels for icons in RTDB page

### DIFF
--- a/src/components/Database/DataViewer/NodeActions.tsx
+++ b/src/components/Database/DataViewer/NodeActions.tsx
@@ -121,6 +121,7 @@ export const NodeActions = React.memo<Props>(function NodeActions$({
     <aside className={'NodeActions' + (isActive ? ' NodeActions--active' : '')}>
       <Tooltip content="Filter children">
         <IconButton
+          label="Filter children"
           icon="filter_list"
           onIcon={<span style={ACTIVE_ICON}>filter_list</span>}
           onClick={() => showQueryUiAndExpand()}
@@ -128,11 +129,12 @@ export const NodeActions = React.memo<Props>(function NodeActions$({
         />
       </Tooltip>
       <Tooltip content="Add child">
-        <IconButton icon="add" onClick={addChild} />
+        <IconButton label="Add child" icon="add" onClick={addChild} />
       </Tooltip>
       {!isRoot ? (
         <Tooltip content="Switch view">
           <IconButton
+            label="Switch view format"
             icon={getToggleIcon(getNextDisplayType(displayType))}
             onClick={() => toggleTable()}
           />
@@ -146,7 +148,7 @@ export const NodeActions = React.memo<Props>(function NodeActions$({
            */
           false
         }
-        handle={<IconButton icon="more_vert" />}
+        handle={<IconButton icon="more_vert" label="More options" />}
         onOpen={() => setMenuOpen(true)}
         onClose={() => setMenuOpen(false)}
       >


### PR DESCRIPTION
This commit updates the icon buttons on the rtdb page to use more meaningful aria-labels (rather than the screen reader simply announcing icon name.)

FIXED=259452471, b/259452471
b/259452471