### PR TITLE
fix(a11y) Recapture focus after closing ImportJson dialog

### DIFF
--- a/src/components/Database/Database.tsx
+++ b/src/components/Database/Database.tsx
@@ -16,7 +16,7 @@
 import { IconButton } from '@rmwc/icon-button';
 import { MenuItem, SimpleMenu } from '@rmwc/menu';
 import { DatabaseReference, ref } from 'firebase/database';
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { useHistory } from 'react-router-dom';
 import { useDatabase } from 'reactfire';
@@ -46,6 +46,7 @@ export const Database: React.FC<React.PropsWithChildren<Props>> = ({
   const namespace = useNamespace();
   const databaseReference = ref(database, path);
   const history = useHistory();
+  const headerMoreOptionsMenuButtonRef = useRef<HTMLButtonElement>();
 
   const [importDialogOpen, setImportDialogOpen] = useState(false);
   const [droppedFile, setDroppedFile] = useState<File | undefined>();
@@ -53,6 +54,7 @@ export const Database: React.FC<React.PropsWithChildren<Props>> = ({
   const closeImportDialog = () => {
     setDroppedFile(undefined);
     setImportDialogOpen(false);
+    headerMoreOptionsMenuButtonRef!.current!.focus();
   };
 
   const urlBase = `/database/${namespace}/data`;
@@ -74,7 +76,13 @@ export const Database: React.FC<React.PropsWithChildren<Props>> = ({
             onNavigate={handleNavigate}
           >
             <SimpleMenu
-              handle={<IconButton icon="more_vert" label="Open menu" />}
+              handle={
+                <IconButton
+                  icon="more_vert"
+                  label="Open menu"
+                  ref={headerMoreOptionsMenuButtonRef}
+                />
+              }
               renderToPortal
             >
               <MenuItem onClick={() => setImportDialogOpen(true)}>

--- a/src/components/Database/Database.tsx
+++ b/src/components/Database/Database.tsx
@@ -16,7 +16,7 @@
 import { IconButton } from '@rmwc/icon-button';
 import { MenuItem, SimpleMenu } from '@rmwc/menu';
 import { DatabaseReference, ref } from 'firebase/database';
-import React, { useRef, useState } from 'react';
+import React, { MutableRefObject, useRef, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { useHistory } from 'react-router-dom';
 import { useDatabase } from 'reactfire';
@@ -46,7 +46,8 @@ export const Database: React.FC<React.PropsWithChildren<Props>> = ({
   const namespace = useNamespace();
   const databaseReference = ref(database, path);
   const history = useHistory();
-  const headerMoreOptionsMenuButtonRef = useRef<HTMLButtonElement>();
+  const headerMoreOptionsMenuButtonRef =
+    useRef() as MutableRefObject<HTMLButtonElement>;
 
   const [importDialogOpen, setImportDialogOpen] = useState(false);
   const [droppedFile, setDroppedFile] = useState<File | undefined>();


### PR DESCRIPTION
This commit fixes an issue where the focus is suddenly lost when the user closes the "Import JSON" on the RTDB page.

Previously, when the dialog closes the focus goes to the bottom of the page (or resets to the head.)

With this commit, we recapture the focus and focus on the "More options" menu. It would have been better to put the focus back on the "Import JSON" button... but the problem is the "Import JSON" button is a child of menu that disappears and becomes un-focusable once selected.

FIXED=259453177, b/259453177

b/259453177