### PR TITLE
fix(a11y) Make RTDB buttons accessible by keyboard

### DIFF
--- a/src/components/Database/DataViewer/NodeParent.scss
+++ b/src/components/Database/DataViewer/NodeParent.scss
@@ -40,13 +40,15 @@ $name: 'NodeParent';
     height: 32px; // to fit buttons
 
     > .NodeActions {
-      display: none;
+      opacity: 0;
       margin-left: 12px;
     }
 
+    &:has(:focus) .NodeActions,
     &:hover > .NodeActions,
     .NodeActions--active {
       display: inline-block;
+      opacity: 100%;
     }
   }
 


### PR DESCRIPTION
This commit fixes an issue where there were multiple buttons were inaccessible using only keyboard.

Two main problems caused this:

1. Relying on `:hover` to change behavior is never accessible
1. Toggling the action buttons using `display: none` removes the ability to focus on them.

The simplest "fix" was using `opacity:0` and `opacity: 100%` to control if the icon buttons are visible. This way, a keyboard user can tab through the buttons... they would just be invisible.

The next fix was to use the `&:has(:focus) .NodeActions` to grant visibility to the buttons if there is any focus inside of the `.NodeParent`.

FIXED=259452291, 259452367, 259452413