### PR TITLE
fix(a11y) Add tooltip to log level, as well as update element type

### DIFF
--- a/src/components/LogViewer/History.scss
+++ b/src/components/LogViewer/History.scss
@@ -51,8 +51,10 @@
 
   .log-level {
     border-radius: 3px;
+    border-width: 0;
     color: rgba(0, 0, 0, 1);
     cursor: pointer;
+    font-family: monospace;
     font-weight: bold;
     grid-area: level;
     padding: 0px 3px;

--- a/src/components/LogViewer/History.tsx
+++ b/src/components/LogViewer/History.tsx
@@ -17,6 +17,7 @@
 import './History.scss';
 
 import { ThemeProvider } from '@rmwc/theme';
+import { Tooltip } from '@rmwc/tooltip';
 import React, { useEffect, useRef } from 'react';
 
 import { grey100 } from '../../colors';
@@ -119,12 +120,15 @@ export const History: React.FC<React.PropsWithChildren<Props>> = ({
                 hour12: false,
               })}
             </span>
-            <span
-              className={`log-level ${log.level}`}
-              onClick={() => appendToQuery('level', log.level)}
-            >
-              {log.level[0].toUpperCase()}
-            </span>
+            <Tooltip content={`Log with level: ${log.level}`}>
+              <button
+                aria-label={`Limit results to logs with log level ${log.level}`}
+                className={`log-level ${log.level}`}
+                onClick={() => appendToQuery('level', log.level)}
+              >
+                {log.level[0].toUpperCase()}
+              </button>
+            </Tooltip>
             <FilterTag appendToQuery={appendToQuery} log={log} />
             {getUserData(log) ? (
               <HighlightedJSON


### PR DESCRIPTION
This commit updates the behavior of log level psudo-button thingy by doing 2 things.

1. Added a too tip
1. Changed the span with onClick to button with onClick (for a11y)
1. Added a more helpful aria-label.

... Guess that was 3. Oh well, can't go back and edit the text, gotta keep going choo-choo.

FIXED=156022730