### PR TITLE
fix(a11y) Add ability to focus on sub icon fields of RTDB

### DIFF
--- a/src/components/Database/DataViewer/NodeLeaf.scss
+++ b/src/components/Database/DataViewer/NodeLeaf.scss
@@ -42,7 +42,7 @@ $name: 'NodeLeaf';
   }
 
   .#{$name}__actions {
-    visibility: hidden;
+    opacity: 0;
     flex: 1;
   }
 
@@ -58,7 +58,8 @@ $name: 'NodeLeaf';
     }
   }
 
+  &:has(:focus) > .#{$name}__actions,
   &:hover > .#{$name}__actions {
-    visibility: visible;
+    opacity: 100%;
   }
 }

--- a/src/components/Database/DataViewer/NodeLeaf.test.tsx
+++ b/src/components/Database/DataViewer/NodeLeaf.test.tsx
@@ -109,7 +109,7 @@ describe('editing the node', () => {
         )
       );
 
-      act(() => getByLabelText('Edit value for: "foo').click());
+      act(() => getByLabelText('Edit value for: "foo"').click());
 
       expect((getByLabelText('Value') as HTMLInputElement).value).toBe(
         'my-value'

--- a/src/components/Database/DataViewer/NodeLeaf.test.tsx
+++ b/src/components/Database/DataViewer/NodeLeaf.test.tsx
@@ -71,7 +71,7 @@ describe('editing the node', () => {
         Promise.resolve(<NodeLeaf realtimeRef={ref(db)} value={null} />)
       );
 
-      act(() => getByLabelText('Edit value').click());
+      act(() => getByLabelText('Edit value for: null').click());
 
       expect((getByLabelText('Field') as HTMLInputElement).value).toMatch(
         /^http:\/\/(localhost|127.0.0.1)/
@@ -83,7 +83,7 @@ describe('editing the node', () => {
         Promise.resolve(<NodeLeaf realtimeRef={ref(db)} value={null} />)
       );
 
-      act(() => getByLabelText('Edit value').click());
+      act(() => getByLabelText('Edit value for: null').click());
 
       expect((getByLabelText('Value') as HTMLInputElement).value).toBe('');
     });
@@ -95,7 +95,7 @@ describe('editing the node', () => {
         Promise.resolve(<NodeLeaf realtimeRef={ref(db)} value={null} />)
       );
 
-      act(() => getByLabelText('Edit value').click());
+      act(() => getByLabelText('Edit value for: null').click());
 
       expect((getByLabelText('Field') as HTMLInputElement).value).toMatch(
         /^http:\/\/(localhost|127.0.0.1)/
@@ -109,7 +109,7 @@ describe('editing the node', () => {
         )
       );
 
-      act(() => getByLabelText('Edit value').click());
+      act(() => getByLabelText('Edit value for: "foo').click());
 
       expect((getByLabelText('Value') as HTMLInputElement).value).toBe(
         'my-value'

--- a/src/components/Database/DataViewer/NodeLeaf.test.tsx
+++ b/src/components/Database/DataViewer/NodeLeaf.test.tsx
@@ -71,7 +71,7 @@ describe('editing the node', () => {
         Promise.resolve(<NodeLeaf realtimeRef={ref(db)} value={null} />)
       );
 
-      act(() => getByLabelText('Edit value for: null').click());
+      act(() => getByLabelText('Edit value for: "null"').click());
 
       expect((getByLabelText('Field') as HTMLInputElement).value).toMatch(
         /^http:\/\/(localhost|127.0.0.1)/
@@ -83,7 +83,7 @@ describe('editing the node', () => {
         Promise.resolve(<NodeLeaf realtimeRef={ref(db)} value={null} />)
       );
 
-      act(() => getByLabelText('Edit value for: null').click());
+      act(() => getByLabelText('Edit value for: "null"').click());
 
       expect((getByLabelText('Value') as HTMLInputElement).value).toBe('');
     });
@@ -95,7 +95,7 @@ describe('editing the node', () => {
         Promise.resolve(<NodeLeaf realtimeRef={ref(db)} value={null} />)
       );
 
-      act(() => getByLabelText('Edit value for: null').click());
+      act(() => getByLabelText('Edit value for: "null"').click());
 
       expect((getByLabelText('Field') as HTMLInputElement).value).toMatch(
         /^http:\/\/(localhost|127.0.0.1)/

--- a/src/components/Database/DataViewer/NodeLeaf.tsx
+++ b/src/components/Database/DataViewer/NodeLeaf.tsx
@@ -77,7 +77,7 @@ export const NodeLeaf = React.memo<Props>(function NodeLeaf$({
           <IconButton
             icon="edit"
             onClick={handleEdit}
-            aria-label={`Edit value for: ${realtimeRef.key}`}
+            aria-label={`Edit value for: "${realtimeRef.key}"`}
           />
         </Tooltip>
         {showAddButton && (

--- a/src/components/Database/DataViewer/NodeLeaf.tsx
+++ b/src/components/Database/DataViewer/NodeLeaf.tsx
@@ -73,23 +73,27 @@ export const NodeLeaf = React.memo<Props>(function NodeLeaf$({
         <ValueDisplay use="body1" value={value} onClick={handleEdit} />
       </div>
       <span className="NodeLeaf__actions">
-        <Tooltip content="Edit value">
+        <Tooltip content={`Edit value for: "${realtimeRef.key}"`}>
           <IconButton
             icon="edit"
             onClick={handleEdit}
-            aria-label="Edit value"
+            aria-label={`Edit value for: ${realtimeRef.key}`}
           />
         </Tooltip>
         {showAddButton && (
-          <Tooltip content="Add child">
-            <IconButton icon="add" onClick={handleAdd} aria-label="Add child" />
+          <Tooltip content={`Add child to "${realtimeRef.key}"`}>
+            <IconButton
+              icon="add"
+              onClick={handleAdd}
+              aria-label={`Add child for "${realtimeRef.key}"`}
+            />
           </Tooltip>
         )}
-        <Tooltip content="Delete value">
+        <Tooltip content={`Delete value for: "${realtimeRef.key}"`}>
           <IconButton
             icon="delete"
             onClick={handleDelete}
-            aria-label="Delete value"
+            aria-label={`Delete value for "${realtimeRef.key}"`}
           />
         </Tooltip>
       </span>


### PR DESCRIPTION
This commit does 2 things:

1. Add ability to focus on the sub icons (add/edit text)
1. Updates the aria-label + tooltip text to be contextually descriptive

FIXED=259452995, b/259452995
b/259452995