### PR TITLE
Firestore dialog fixes for a11y

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ To run the test runner with emulators, use:
 
 ```bash
 firebase emulators:exec --project sample --only firestore 'npm test'
+
+firebase emulators:exec --project sample --only firestore 'npm test AddCollectionDialog.test.tsx'
 ```
 
 If you get port conflict errors, make sure to stop other instances of the Firebase Emulator Suite (e.g. the one you've started for the development server above) and try again.

--- a/src/components/Firestore/CollectionList.test.tsx
+++ b/src/components/Firestore/CollectionList.test.tsx
@@ -119,8 +119,6 @@ it('triggers a redirect to a new collection at the root', async () => {
     });
   });
 
-  act(() => getByText(/Next/).click());
-
   await act(async () => {
     fireEvent.change(getByLabelText(/Field/), {
       target: { value: 'foo' },
@@ -164,8 +162,6 @@ it('triggers a redirect to a new collection at the root when there are special c
       target: { value: 'abc@#$' },
     });
   });
-
-  act(() => getByText(/Next/).click());
 
   await act(async () => {
     fireEvent.change(getByLabelText(/Field/), {
@@ -214,8 +210,6 @@ it('triggers a redirect to a new collection in a document', async () => {
     });
   });
 
-  act(() => getByText(/Next/).click());
-
   await act(async () => {
     fireEvent.change(getByLabelText(/Field/), {
       target: { value: 'foo' },
@@ -262,8 +256,6 @@ it('triggers a redirect to a new collection in a document when there are special
       target: { value: 'abc@#$' },
     });
   });
-
-  act(() => getByText(/Next/).click());
 
   await act(async () => {
     fireEvent.change(getByLabelText(/Field/), {

--- a/src/components/Firestore/dialogs/AddCollectionDialog.test.tsx
+++ b/src/components/Firestore/dialogs/AddCollectionDialog.test.tsx
@@ -161,6 +161,8 @@ describe('at the root of the db', () => {
       <AddCollectionDialog open={true} onValue={() => {}} />
     ));
 
-    expect((getByLabelText(/Parent path/) as HTMLInputElement).value).toBe('<parent Collection ID>');
+    expect((getByLabelText(/Parent path/) as HTMLInputElement).value).toBe(
+      '<parent Collection ID>'
+    );
   });
 }); // at the root of the db

--- a/src/components/Firestore/dialogs/AddCollectionDialog.test.tsx
+++ b/src/components/Firestore/dialogs/AddCollectionDialog.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { RenderResult, fireEvent, waitFor } from '@testing-library/react';
+import { RenderResult, fireEvent, waitFor } from '@testing-library/react'; // FIXME tests
 import { doc } from 'firebase/firestore';
 import React from 'react';
 import { act } from 'react-dom/test-utils';

--- a/src/components/Firestore/dialogs/AddCollectionDialog.test.tsx
+++ b/src/components/Firestore/dialogs/AddCollectionDialog.test.tsx
@@ -19,7 +19,7 @@ import { doc } from 'firebase/firestore';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
-import { delay, waitForDialogsToClose } from '../../../test_utils';
+import { waitForDialogsToClose } from '../../../test_utils';
 import { renderWithFirestore } from '../testing/FirestoreTestProviders';
 import { renderDialogWithFirestore } from '../testing/test_utils';
 import { AddCollectionDialog } from './AddCollectionDialog';

--- a/src/components/Firestore/dialogs/AddCollectionDialog.test.tsx
+++ b/src/components/Firestore/dialogs/AddCollectionDialog.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { RenderResult, fireEvent, waitFor } from '@testing-library/react'; // FIXME tests
+import { RenderResult, fireEvent, waitFor } from '@testing-library/react';
 import { doc } from 'firebase/firestore';
 import React from 'react';
 import { act } from 'react-dom/test-utils';

--- a/src/components/Firestore/dialogs/AddCollectionDialog.test.tsx
+++ b/src/components/Firestore/dialogs/AddCollectionDialog.test.tsx
@@ -52,7 +52,7 @@ describe('step 1', () => {
     );
 
     expect((getByLabelText(/Parent path/) as HTMLInputElement).value).toBe(
-      'docs/my-doc'
+      'docs/my-doc/<parent Collection ID>'
     );
   });
 
@@ -85,12 +85,6 @@ describe('step 2', () => {
 
     fireEvent.change(getByLabelText(/Collection ID/), {
       target: { value: 'my-col' },
-    });
-
-    await act(async () => {
-      getByText('Next').click();
-      // Wait for async Dialogs DOM changes for the second step dialog.
-      await delay(100);
     });
   });
 
@@ -167,6 +161,6 @@ describe('at the root of the db', () => {
       <AddCollectionDialog open={true} onValue={() => {}} />
     ));
 
-    expect((getByLabelText(/Parent path/) as HTMLInputElement).value).toBe('/');
+    expect((getByLabelText(/Parent path/) as HTMLInputElement).value).toBe('<parent Collection ID>');
   });
 }); // at the root of the db

--- a/src/components/Firestore/dialogs/AddCollectionDialog.tsx
+++ b/src/components/Firestore/dialogs/AddCollectionDialog.tsx
@@ -31,12 +31,10 @@ import { Field } from '../../common/Field';
 import { AddDocumentDialogValue, AddDocumentStep } from './AddDocumentDialog';
 
 interface AddCollectionStepProps {
-  documentRef?: DocumentReference;
   onChange: (value: string) => void;
 }
 
 export const AddCollectionStep = ({
-  documentRef,
   onChange,
 }: AddCollectionStepProps) => {
   const [id, setId] = useState('');
@@ -47,12 +45,6 @@ export const AddCollectionStep = ({
 
   return (
     <>
-      <Field
-        label="Parent path"
-        value={documentRef ? documentRef.path : '/'}
-        disabled
-      />
-
       <Field label="Collection ID" required value={id} onChange={updateId} />
     </>
   );
@@ -68,11 +60,6 @@ interface Props extends DialogProps {
   onValue: (v: AddCollectionDialogValue | null) => void;
 }
 
-enum Step {
-  COLLECTION,
-  DOCUMENT,
-}
-
 export const AddCollectionDialog: React.FC<React.PropsWithChildren<Props>> = ({
   documentRef,
   onValue,
@@ -80,15 +67,11 @@ export const AddCollectionDialog: React.FC<React.PropsWithChildren<Props>> = ({
   ...dialogProps
 }) => {
   const firestore = useFirestore();
-  const [step, setStep] = useState(Step.COLLECTION);
   const [collectionId, setCollectionId] = useState('');
   const [document, setDocument] = useState<AddDocumentDialogValue>({
     id: '',
     data: undefined,
   });
-
-  const next = () =>
-    step === Step.COLLECTION && collectionId && setStep(step + 1);
 
   const getValue = () => ({
     collectionId,
@@ -100,46 +83,40 @@ export const AddCollectionDialog: React.FC<React.PropsWithChildren<Props>> = ({
     onClose && onClose(evt);
   };
 
+  function getCurrentOrPlaceholderCollectionId(collectionId: string) {
+    return collectionId ? collectionId : "<parent Collection ID>";
+  }
+
   return (
     <Dialog {...dialogProps} onClose={emitValueAndClose}>
       <DialogTitle>Start a collection</DialogTitle>
 
       <DialogContent>
-        {step === Step.COLLECTION ? (
-          <AddCollectionStep
-            documentRef={documentRef}
-            onChange={setCollectionId}
-          />
-        ) : (
-          <AddDocumentStep
-            collectionRef={
-              documentRef
-                ? collection(documentRef, collectionId)
-                : collection(firestore, collectionId)
-            }
-            onChange={setDocument}
-          />
-        )}
+        <AddCollectionStep
+          onChange={setCollectionId}
+        />
+        <AddDocumentStep
+          collectionRef={
+            documentRef
+              ? collection(documentRef, getCurrentOrPlaceholderCollectionId(collectionId))
+              : collection(firestore, getCurrentOrPlaceholderCollectionId(collectionId))
+          }
+          onChange={setDocument}
+        />
       </DialogContent>
 
       <DialogActions>
         <DialogButton action="close" type="button" theme="secondary">
           Cancel
         </DialogButton>
-        {step === Step.DOCUMENT ? (
-          <DialogButton
-            unelevated
-            action="accept"
-            isDefaultAction
-            disabled={!document.data}
-          >
-            Save
-          </DialogButton>
-        ) : (
-          <DialogButton unelevated onClick={next}>
-            Next
-          </DialogButton>
-        )}
+        <DialogButton
+          unelevated
+          action="accept"
+          isDefaultAction
+          disabled={!document.data || !document.id || !collectionId}
+        >
+          Save
+        </DialogButton>
       </DialogActions>
     </Dialog>
   );

--- a/src/components/Firestore/dialogs/AddCollectionDialog.tsx
+++ b/src/components/Firestore/dialogs/AddCollectionDialog.tsx
@@ -34,9 +34,7 @@ interface AddCollectionInputProps {
   onChange: (value: string) => void;
 }
 
-export const AddCollectionInput = ({
-  onChange,
-}: AddCollectionInputProps) => {
+export const AddCollectionInput = ({ onChange }: AddCollectionInputProps) => {
   const [id, setId] = useState('');
   const updateId = (evt: React.ChangeEvent<HTMLInputElement>) => {
     setId(evt.target.value);
@@ -84,7 +82,7 @@ export const AddCollectionDialog: React.FC<React.PropsWithChildren<Props>> = ({
   };
 
   function getCurrentOrPlaceholderCollectionId(collectionId: string) {
-    return collectionId ? collectionId : "<parent Collection ID>";
+    return collectionId ? collectionId : '<parent Collection ID>';
   }
 
   return (
@@ -92,14 +90,18 @@ export const AddCollectionDialog: React.FC<React.PropsWithChildren<Props>> = ({
       <DialogTitle>Start a collection</DialogTitle>
 
       <DialogContent>
-        <AddCollectionInput
-          onChange={setCollectionId}
-        />
+        <AddCollectionInput onChange={setCollectionId} />
         <AddDocumentStep
           collectionRef={
             documentRef
-              ? collection(documentRef, getCurrentOrPlaceholderCollectionId(collectionId))
-              : collection(firestore, getCurrentOrPlaceholderCollectionId(collectionId))
+              ? collection(
+                  documentRef,
+                  getCurrentOrPlaceholderCollectionId(collectionId)
+                )
+              : collection(
+                  firestore,
+                  getCurrentOrPlaceholderCollectionId(collectionId)
+                )
           }
           onChange={setDocument}
         />

--- a/src/components/Firestore/dialogs/AddCollectionDialog.tsx
+++ b/src/components/Firestore/dialogs/AddCollectionDialog.tsx
@@ -30,13 +30,13 @@ import { useFirestore } from 'reactfire';
 import { Field } from '../../common/Field';
 import { AddDocumentDialogValue, AddDocumentStep } from './AddDocumentDialog';
 
-interface AddCollectionStepProps {
+interface AddCollectionInputProps {
   onChange: (value: string) => void;
 }
 
-export const AddCollectionStep = ({
+export const AddCollectionInput = ({
   onChange,
-}: AddCollectionStepProps) => {
+}: AddCollectionInputProps) => {
   const [id, setId] = useState('');
   const updateId = (evt: React.ChangeEvent<HTMLInputElement>) => {
     setId(evt.target.value);
@@ -92,7 +92,7 @@ export const AddCollectionDialog: React.FC<React.PropsWithChildren<Props>> = ({
       <DialogTitle>Start a collection</DialogTitle>
 
       <DialogContent>
-        <AddCollectionStep
+        <AddCollectionInput
           onChange={setCollectionId}
         />
         <AddDocumentStep

--- a/src/components/Firestore/dialogs/AddDocumentDialog.tsx
+++ b/src/components/Firestore/dialogs/AddDocumentDialog.tsx
@@ -124,7 +124,7 @@ export const AddDocumentDialog: React.FC<React.PropsWithChildren<Props>> = ({
           unelevated
           action="accept"
           isDefaultAction
-          disabled={!document.data}
+          disabled={!document.data || !document.id}
         >
           Save
         </DialogButton>


### PR DESCRIPTION
Fixed the focus capture issue, double target on save, tab ordering. This changes from a 2-dialog collection creation flow to a single dialog

![image](https://user-images.githubusercontent.com/106194718/207209349-22ecc3db-6c58-4596-9f10-f9e3a2478edc.png)
