### PR TITLE
Use address instead of host when determining the URL to use.

### DIFF
--- a/src/components/common/EmulatorConfigProvider.tsx
+++ b/src/components/common/EmulatorConfigProvider.tsx
@@ -217,10 +217,10 @@ async function configFetcher(url: string): Promise<Config> {
     // remotely and connect from another device. It does not work for some setups
     // e.g. when Emulator UI is proxied but not the individual emulators.
     for (const listen of (value.listen ?? []) as {
-      host: string;
+      address: string;
       port: number;
     }[]) {
-      if (listen.host === '0.0.0.0') {
+      if (listen.address === '0.0.0.0') {
         port = listen.port;
         host = window.location.hostname;
         if (!host || host === 'localhost') {
@@ -229,7 +229,7 @@ async function configFetcher(url: string): Promise<Config> {
           host = '127.0.0.1';
         }
         break;
-      } else if (listen.host === '::') {
+      } else if (listen.address === '::') {
         port = listen.port;
         host = window.location.hostname;
         if (!host || host === 'localhost') {


### PR DESCRIPTION
Querying the hub for the emulator config by requesting`127.0.0.1:4400/emulators` gives the following:

```json
{
  "hub": {
    "listen": [
      {
        "address": "0.0.0.0",
        "family": "IPv4",
        "port": 4400
      }
    ],
    "name": "hub",
    "host": "127.0.0.1",
    "port": 4400
  },
  "ui": {
    "listen": [
      {
        "address": "0.0.0.0",
        "family": "IPv4",
        "port": 4000
      }
    ],
    "name": "ui",
    "host": "127.0.0.1",
    "port": 4000,
    "pid": 66
  }
}
```

The `listen.address` is `0.0.0.0`, so I would expect the UI logic to default to `window.location.hostname` but instead the links I see in the UI are `127.0.0.1`. This appears to be because the code is looking at `listen.host` instead of `listen.address`. Changing references to `listen.host` to `listen.address` fixed the issue, and the UI links used the window's location instead of `127.0.0.1`.