### PR TITLE
Custom auth handler support

### DIFF
--- a/src/components/Auth/CustomAuthActionUriCard/CustomAuthActionUriCard.test.tsx
+++ b/src/components/Auth/CustomAuthActionUriCard/CustomAuthActionUriCard.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Portal } from '@rmwc/base';
+import { fireEvent, render } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+
+import { waitForDialogsToOpen } from '../../../test_utils';
+import { getMockAuthStore } from '../test_utils';
+import {
+  CustomAuthActionUriCard,
+  CustomAuthActionUriCardProps,
+} from './CustomAuthActionUriCard';
+
+describe('CustomAuthActionUriCard', () => {
+  function setup(props: CustomAuthActionUriCardProps) {
+    const store = getMockAuthStore();
+
+    return render(
+      <Provider store={store}>
+        <Portal />
+        <CustomAuthActionUriCard {...props} />
+      </Provider>
+    );
+  }
+
+  it('opens the dialog', async () => {
+    const { getByText, queryByRole } = setup({ customAuthActionUri: "https://example.com" });
+
+    expect(queryByRole('alertdialog')).toBeNull();
+    fireEvent.click(getByText('Change'));
+    await waitForDialogsToOpen();
+    expect(queryByRole('alertdialog')).not.toBeNull();
+  });
+
+  describe('content', () => {
+    it('displays appropriate text when not set', () => {
+      const { queryByText } = setup({ customAuthActionUri: "" });
+      expect(queryByText(/Default Auth Action Handler/)).not.toBeNull();
+      expect(queryByText(/Custom Auth Action Handler/)).toBeNull();
+    });
+
+    it('displays appropriate text when set', () => {
+      const { queryByText } = setup({ customAuthActionUri: "https://example.com" });
+      expect(queryByText(/Default Auth Action Handler/)).toBeNull();
+      expect(queryByText(/Custom Auth Action Handler/)).not.toBeNull();
+    });
+  });
+});

--- a/src/components/Auth/CustomAuthActionUriCard/CustomAuthActionUriCard.tsx
+++ b/src/components/Auth/CustomAuthActionUriCard/CustomAuthActionUriCard.tsx
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button } from '@rmwc/button';
+import { Card } from '@rmwc/card';
+import { Typography } from '@rmwc/typography';
+import React, { useState } from 'react';
+import { connect } from 'react-redux';
+
+import { createStructuredSelector } from '../../../store';
+import { getCustomAuthActionUri } from '../../../store/auth/selectors';
+import styles from '../OneAccountPerEmailCard/OneAccountPerEmailCard.module.scss'; // styles are the same
+import CustomAuthActionUriDialog from './CustomAuthActionUriDialog';
+
+export type CustomAuthActionUriCardProps = PropsFromStore;
+export const CustomAuthActionUriCard: React.FC<
+  React.PropsWithChildren<CustomAuthActionUriCardProps>
+> = ({ customAuthActionUri }) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Card className={styles.wrapper}>
+        {customAuthActionUri ? (
+          <div>
+            <Typography
+              use="headline6"
+              tag="div"
+              theme="textPrimaryOnBackground"
+            >
+              Custom Auth Action Handler
+            </Typography>
+            <Typography use="body2" theme="textPrimaryOnBackground">
+              The emulator will output links to your custom handler
+              for auth actions like resetting passwords.{' '}
+              <a
+                target="_blank"
+                rel="noopener noreferrer"
+                href="https://support.google.com/firebase/answer/7000714#actionlink"
+              >
+                Learn more
+              </a>
+            </Typography>
+          </div>
+        ) : (
+          <div>
+            <Typography
+              use="headline6"
+              tag="div"
+              theme="textPrimaryOnBackground"
+            >
+              Default Auth Action Handler
+            </Typography>
+            <Typography use="body2" theme="textPrimaryOnBackground">
+              The emulator will output links to its default handler
+              for auth actions like resetting passwords.
+            </Typography>
+          </div>
+        )}
+
+        <div>
+          <Button outlined={true} onClick={() => setOpen(true)}>
+            Change
+          </Button>
+        </div>
+      </Card>
+      {open && <CustomAuthActionUriDialog onClose={() => setOpen(false)} />}
+    </>
+  );
+};
+export const mapStateToProps = createStructuredSelector({
+  customAuthActionUri: getCustomAuthActionUri,
+});
+
+export type PropsFromStore = ReturnType<typeof mapStateToProps>;
+export default connect(mapStateToProps)(CustomAuthActionUriCard);

--- a/src/components/Auth/CustomAuthActionUriCard/CustomAuthActionUriDialog.test.tsx
+++ b/src/components/Auth/CustomAuthActionUriCard/CustomAuthActionUriDialog.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Portal } from '@rmwc/base';
+import { fireEvent, render } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+
+import { AppState } from '../../../store';
+import { createFakeAuthStateWithUsers } from '../test_utils';
+import { CustomAuthActionUriDialog } from './CustomAuthActionUriDialog';
+
+describe('CustomAuthActionUriDialog', () => {
+  function setup(customAuthActionUri = "") {
+    const onClose = jest.fn();
+    const setCustomAuthActionUri = jest.fn();
+
+    const store = configureStore<Pick<AppState, 'auth'>>()({
+      auth: createFakeAuthStateWithUsers([]),
+    });
+
+    const methods = render(
+      <Provider store={store}>
+        <Portal />
+        <CustomAuthActionUriDialog
+          customAuthActionUri={customAuthActionUri}
+          onClose={onClose}
+          setCustomAuthActionUri={setCustomAuthActionUri}
+        />
+      </Provider>
+    );
+
+    return {
+      onClose,
+      setCustomAuthActionUri,
+      ...methods,
+    };
+  }
+
+  it('calls onClose on hitting "save" button', async () => {
+    const { getByText, onClose } = setup();
+    fireEvent.submit(getByText('Save'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('calls setCustomAuthActionUri on hitting "save" button', async () => {
+    const { getByText, setCustomAuthActionUri } = setup();
+    fireEvent.submit(getByText('Save'));
+    expect(setCustomAuthActionUri).toHaveBeenCalledWith("");
+  });
+
+  it('updates value', async () => {
+    const { getByText, setCustomAuthActionUri, getByLabelText } = setup("https://example.com");
+
+    const input = getByLabelText(/Custom handler URL/);
+
+    fireEvent.change(input, {target: {value: ""}});
+
+    fireEvent.submit(getByText('Save'));
+    expect(setCustomAuthActionUri).toHaveBeenCalledWith("");
+  });
+
+  it('calls onClose on hitting "cancel" button', async () => {
+    const { getByText, onClose } = setup();
+    fireEvent.click(getByText('Cancel'));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/Auth/CustomAuthActionUriCard/CustomAuthActionUriDialog.tsx
+++ b/src/components/Auth/CustomAuthActionUriCard/CustomAuthActionUriDialog.tsx
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Dialog,
+  DialogActions,
+  DialogButton,
+  DialogContent,
+  DialogTitle,
+} from '@rmwc/dialog';
+import { Typography } from '@rmwc/typography';
+import React from 'react';
+import { MapDispatchToPropsFunction, connect } from 'react-redux';
+
+import { createStructuredSelector } from '../../../store';
+import { setCustomAuthActionUriRequest } from '../../../store/auth/actions';
+import { getCustomAuthActionUri } from '../../../store/auth/selectors';
+import { Field } from '../../common/Field';
+import styles from '../OneAccountPerEmailCard/OneAccountPerEmailDialog.module.scss'; // The styles are the same for both dialogs
+
+interface CustomAuthActionUriDialogProps {
+  onClose: () => void;
+}
+
+type Props = PropsFromDispatch & PropsFromStore & CustomAuthActionUriDialogProps;
+
+export const CustomAuthActionUriDialog: React.FC<
+  React.PropsWithChildren<Props>
+> = ({ customAuthActionUri, onClose, setCustomAuthActionUri }) => {
+  const [value, setValue] = React.useState(customAuthActionUri);
+
+  return (
+    <Dialog renderToPortal open onClose={onClose}>
+      <DialogTitle>Auth Action Handler Settings</DialogTitle>
+      <form
+        onSubmit={(e: React.FormEvent<unknown>) => {
+          e.preventDefault();
+          setCustomAuthActionUri(value);
+          onClose();
+        }}
+      >
+        <DialogContent>
+          <Typography use="body2" className={styles.description}>
+            This setting allows you to test a custom auth action handler
+            for when users try to verify their emails, reset their passwords,
+            or revoke an email address change.
+          </Typography>           
+          <Field 
+            value={value}
+            onChange={(event: any) => setValue(event.target.value)}
+            label="Custom handler URL"
+            type="url"
+            placeholder="Leave blank to use the default handler"
+          />
+        </DialogContent>
+        <DialogActions>
+          <DialogButton action="close" type="button" theme="secondary">
+            Cancel
+          </DialogButton>
+          <DialogButton type="submit" unelevated>
+            Save
+          </DialogButton>
+        </DialogActions>
+      </form>
+    </Dialog>
+  );
+};
+
+export const mapStateToProps = createStructuredSelector({
+  customAuthActionUri: getCustomAuthActionUri,
+});
+
+export type PropsFromStore = ReturnType<typeof mapStateToProps>;
+
+export interface PropsFromDispatch {
+  setCustomAuthActionUri: typeof setCustomAuthActionUriRequest;
+}
+
+export const mapDispatchToProps: MapDispatchToPropsFunction<
+  PropsFromDispatch,
+  {}
+> = (dispatch) => ({
+  setCustomAuthActionUri: (value: string) =>
+    dispatch(setCustomAuthActionUriRequest(value)),
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(CustomAuthActionUriDialog);

--- a/src/components/Auth/api.test.ts
+++ b/src/components/Auth/api.test.ts
@@ -308,9 +308,10 @@ describe('API', () => {
 
   it('updateConfig', async () => {
     const allowDuplicateEmails = false;
-    const mockFetchResult = { signIn: { allowDuplicateEmails } };
+    const callbackUri = "";
+    const mockFetchResult = { signIn: { allowDuplicateEmails }, notification: { sendEmail: { callbackUri } } };
     const api = setup({ mockFetchResult });
-    const result = await api.updateConfig({ signIn: { allowDuplicateEmails } });
+    const result = await api.updateConfig({ signIn: { allowDuplicateEmails }, notification: { sendEmail: { callbackUri } }  });
     expect(global.fetch).toHaveBeenCalledWith(
       '//foo.example.com:9002/emulator/v1/projects/pelmen-the-project/config',
       {
@@ -327,7 +328,7 @@ describe('API', () => {
   });
 
   it('getConfig', async () => {
-    const mockFetchResult = { signIn: { allowDuplicateEmails: false } };
+    const mockFetchResult = { signIn: { allowDuplicateEmails: false }, notification: { sendEmail: { callbackUri: "" } }  };
     const api = setup({ mockFetchResult });
     const result = await api.getConfig();
     expect(global.fetch).toHaveBeenCalledWith(

--- a/src/components/Auth/index.tsx
+++ b/src/components/Auth/index.tsx
@@ -33,6 +33,7 @@ import { EmulatorDisabled } from '../common/EmulatorDisabled';
 import { Spinner } from '../common/Spinner';
 import styles from './index.module.scss';
 import OneAccountPerEmailCard from './OneAccountPerEmailCard/OneAccountPerEmailCard';
+import CustomAuthActionUriCard from './CustomAuthActionUriCard/CustomAuthActionUriCard';
 import ClearAll from './UsersCard/ClearAll';
 import TenantPicker, { useTenantFromUrl } from './UsersCard/TenantPicker';
 import UsersCard from './UsersCard/UsersCard';
@@ -90,6 +91,9 @@ export const Auth: React.FC<React.PropsWithChildren<AuthProps>> = ({
       </Elevation>
       <Elevation z="2" wrap>
         <OneAccountPerEmailCard />
+      </Elevation>
+      <Elevation z="2" wrap>
+        <CustomAuthActionUriCard />
       </Elevation>
     </GridCell>
   );

--- a/src/components/Auth/test_utils.ts
+++ b/src/components/Auth/test_utils.ts
@@ -26,6 +26,7 @@ export function getMockAuthStore(state?: Partial<AppState['auth']>) {
       users: { loading: false, result: { data: [] } },
       filter: '',
       allowDuplicateEmails: false,
+      customAuthActionUri: "",
       tenants: { loading: false, result: { data: [] } },
       ...state,
     },
@@ -62,6 +63,7 @@ export function createFakeState(state: Partial<AuthState>): AuthState {
   return {
     filter: '',
     allowDuplicateEmails: true,
+    customAuthActionUri: "https://example.com/",
     users: createRemoteDataLoaded([]),
     tenants: createRemoteDataLoaded([]),
     ...state,

--- a/src/components/Auth/types.ts
+++ b/src/components/Auth/types.ts
@@ -104,6 +104,7 @@ export interface AuthState {
   users: RemoteResult<AuthUser[]>;
   filter: string;
   allowDuplicateEmails: boolean;
+  customAuthActionUri: string;
   tenants: RemoteResult<Tenant[]>;
 }
 
@@ -111,4 +112,5 @@ export interface AuthState {
 // but without optional types
 export interface EmulatorV1ProjectsConfig {
   signIn: { allowDuplicateEmails: boolean };
+  notification: { sendEmail: { callbackUri: string } };
 }

--- a/src/store/auth/actions.tsx
+++ b/src/store/auth/actions.tsx
@@ -114,6 +114,22 @@ export const getAllowDuplicateEmailsSuccess = createAction(
   '@auth/GET_ALLOW_DUPLICATE_EMAILS_SUCCESS'
 )<boolean>();
 
+export const setCustomAuthActionUriRequest = createAction(
+  '@auth/SET_CUSTOM_AUTH_ACTION_URI_REQUEST'
+)<string>();
+
+export const setCustomAuthActionUriSuccess = createAction(
+  '@auth/SET_CUSTOM_AUTH_ACTION_URI_SUCCESS'
+)<string>();
+
+export const getCustomAuthActionUriRequest = createAction(
+  '@auth/GET_CUSTOM_AUTH_ACTION_URI_REQUEST'
+)();
+
+export const getCustomAuthActionUriSuccess = createAction(
+  '@auth/GET_CUSTOM_AUTH_ACTION_URI_SUCCESS'
+)<string>();
+
 export const openAuthUserDialog = createAction(
   '@auth/SET_AUTH_USER_DIALOG_DATA'
 )<RemoteResult<AuthUser | undefined>>();

--- a/src/store/auth/reducer.test.ts
+++ b/src/store/auth/reducer.test.ts
@@ -31,6 +31,7 @@ import {
   deleteUserSuccess,
   nukeUsersSuccess,
   setAllowDuplicateEmailsSuccess,
+  setCustomAuthActionUriSuccess,
   setUserDisabledSuccess,
   updateFilter,
   updateUserSuccess,
@@ -136,6 +137,15 @@ describe('auth reducers', () => {
 
       const result = authReducer(state, action);
       expect(result.allowDuplicateEmails).toEqual(allowDuplicateEmails);
+    });
+
+    it(`${setCustomAuthActionUriSuccess} => sets the config value`, () => {
+      const customAuthActionUri = "https://example.com/";
+      const state = createFakeState({ customAuthActionUri: "" });
+      const action = setCustomAuthActionUriSuccess(customAuthActionUri);
+
+      const result = authReducer(state, action);
+      expect(result.customAuthActionUri).toEqual(customAuthActionUri);
     });
   });
 

--- a/src/store/auth/reducer.tsx
+++ b/src/store/auth/reducer.tsx
@@ -25,6 +25,7 @@ const INIT_STATE = {
   users: { loading: true },
   filter: '',
   allowDuplicateEmails: false,
+  customAuthActionUri: '',
   tenants: { loading: true },
 };
 
@@ -61,6 +62,14 @@ export const authReducer = createReducer<AuthState, Action>(INIT_STATE)
     (state, { payload }) => {
       return produce(state, (draft) => {
         draft.allowDuplicateEmails = payload;
+      });
+    }
+  )
+  .handleAction(
+    authActions.setCustomAuthActionUriSuccess,
+    (state, { payload }) => {
+      return produce(state, (draft) => {
+        draft.customAuthActionUri = payload;
       });
     }
   )

--- a/src/store/auth/sagas.ts
+++ b/src/store/auth/sagas.ts
@@ -41,6 +41,7 @@ import {
   deleteUserRequest,
   deleteUserSuccess,
   getAllowDuplicateEmailsRequest,
+  getCustomAuthActionUriRequest,
   nukeUsersForAllTenantsRequest,
   nukeUsersForAllTenantsSuccess,
   nukeUsersRequest,
@@ -49,6 +50,8 @@ import {
   setAllowDuplicateEmailsSuccess,
   setAuthUserDialogError,
   setAuthUserDialogLoading,
+  setCustomAuthActionUriRequest,
+  setCustomAuthActionUriSuccess,
   setUserDisabledRequest,
   setUserDisabledSuccess,
   updateAuthConfig,
@@ -103,9 +106,18 @@ export function* initAuth({ payload }: ActionType<typeof updateAuthConfig>) {
       getType(getAllowDuplicateEmailsRequest),
       getAllowDuplicateEmails
     ),
+    takeLatest(
+      getType(setCustomAuthActionUriRequest),
+      setCustomAuthActionUri
+    ),
+    takeLatest(
+      getType(getCustomAuthActionUriRequest),
+      getCustomAuthActionUri
+    ),
     put(authFetchUsersRequest()),
     put(authFetchTenantsRequest()),
     put(getAllowDuplicateEmailsRequest()),
+    put(getCustomAuthActionUriRequest()),
   ]);
 }
 
@@ -197,6 +209,24 @@ export function* getAllowDuplicateEmails() {
   }
 
   yield put(setAllowDuplicateEmailsSuccess(config.signIn.allowDuplicateEmails));
+}
+
+export function* setCustomAuthActionUri({
+  payload,
+}: ReturnType<typeof setCustomAuthActionUriRequest>) {
+  const authApi: AuthApi = yield call(configureAuthSaga);
+  yield call([authApi, 'updateConfig'], {
+    notification: { sendEmail: { callbackUri: payload } },
+  });
+  yield put(setCustomAuthActionUriSuccess(payload));
+}
+
+export function* getCustomAuthActionUri() {
+  const authApi: AuthApi = yield call(configureAuthSaga);
+  const config: EmulatorV1ProjectsConfig = yield call([authApi, 'getConfig']);
+  const customAuthActionUri = config.notification?.sendEmail?.callbackUri ?? "";
+
+  yield put(setCustomAuthActionUriSuccess(customAuthActionUri));
 }
 
 export function* nukeUsers() {

--- a/src/store/auth/selectors.ts
+++ b/src/store/auth/selectors.ts
@@ -85,6 +85,11 @@ export const getAllowDuplicateEmails = createSelector(
   (state: AuthState) => state.allowDuplicateEmails
 );
 
+export const getCustomAuthActionUri = createSelector(
+  getAuth,
+  (state: AuthState) => state.customAuthActionUri
+);
+
 export const getFilteredUsers = createSelector(
   getUsers,
   getFilter,


### PR DESCRIPTION
This allows changing the auth handler URL through a dialog in the emulator UI

Related PR that adds the REST API support for this: firebase/firebase-tools#5360