### PR TITLE
fix(a11y) Update "IMPORT JSON" MenuItem to respond to keyboard-only

### DIFF
--- a/src/components/Database/Database.tsx
+++ b/src/components/Database/Database.tsx
@@ -77,6 +77,14 @@ export const Database: React.FC<React.PropsWithChildren<Props>> = ({
             onNavigate={handleNavigate}
           >
             <SimpleMenu
+              onSelect={(evt) => {
+                switch (evt.detail?.item?.dataset?.value) {
+                  case "IMPORT_JSON":
+                    setImportDialogOpen(true);
+                    return;
+                  default:
+                }
+              }}
               handle={
                 <IconButton
                   icon="more_vert"
@@ -86,7 +94,7 @@ export const Database: React.FC<React.PropsWithChildren<Props>> = ({
               }
               renderToPortal
             >
-              <MenuItem onClick={() => setImportDialogOpen(true)}>
+              <MenuItem data-value="IMPORT_JSON">
                 Import JSON
               </MenuItem>
             </SimpleMenu>

--- a/src/components/Database/Database.tsx
+++ b/src/components/Database/Database.tsx
@@ -79,7 +79,7 @@ export const Database: React.FC<React.PropsWithChildren<Props>> = ({
             <SimpleMenu
               onSelect={(evt) => {
                 switch (evt.detail?.item?.dataset?.value) {
-                  case "IMPORT_JSON":
+                  case 'IMPORT_JSON':
                     setImportDialogOpen(true);
                     return;
                   default:
@@ -94,9 +94,7 @@ export const Database: React.FC<React.PropsWithChildren<Props>> = ({
               }
               renderToPortal
             >
-              <MenuItem data-value="IMPORT_JSON">
-                Import JSON
-              </MenuItem>
+              <MenuItem data-value="IMPORT_JSON">Import JSON</MenuItem>
             </SimpleMenu>
           </InteractiveBreadCrumbBar>
 


### PR DESCRIPTION
This commit updates the SimpleMenu and the MenuItem associated with the "Import Json" MenuItem such that you can activate/select the "Import Json" dialog using the keyboard.

The problem before was pressing "Enter" or "Space" would not activate the "onClick" handler.

But, it would bubble up a "selected" event.

So instead I moved the "selected" behavior into the Menu and am using a dataset attribute to control behavior.

FIXED=259452701, b/259452701