### PR TITLE
fix(a11y) Remove unnecessary scrollbars from Firestore tables

### DIFF
--- a/src/components/common/CardActionBar.scss
+++ b/src/components/common/CardActionBar.scss
@@ -25,6 +25,7 @@
     box-shadow: $GMP_SHADOW_DIVIDER_BOTTOM_INSET;
     display: flex;
     height: 56px;
+    overflow: hidden;
   }
 
   .CardActionBar-actions {


### PR DESCRIPTION
This commit fixes an issue where the scrollbars in the "Action Panels" of the Firestore tables were visible.

The bug was created from an older commit where I changed the `display` prop to `flex` but didn't change the `overflow` value. ... so we got some scrolls.

The fix is simply adding `overflow: hidden` fixed it.

I was able reproduce the issue on Firefox, and the fix appears to work.

FIXED=263429470, b/263429470