### PR TITLE
Fixes #5399 by reverting the `overflow` of Firestore CardActionBar

### DIFF
--- a/src/components/Firestore/PanelHeader.scss
+++ b/src/components/Firestore/PanelHeader.scss
@@ -18,7 +18,7 @@
 
 .Firestore-PanelHeader {
   .CardActionBar {
-    overflow: scroll;
+    overflow: visible;
   }
   .CardActionBar-container {
     padding: 8px 12px;

--- a/src/components/common/CardActionBar.scss
+++ b/src/components/common/CardActionBar.scss
@@ -25,7 +25,7 @@
     box-shadow: $GMP_SHADOW_DIVIDER_BOTTOM_INSET;
     display: flex;
     height: 56px;
-    overflow: hidden;
+    overflow: visible;
   }
 
   .CardActionBar-actions {


### PR DESCRIPTION
This commit fixes https://github.com/firebase/firebase-tools/issues/5399.
The regression was introduced in #888.

This reverts a minor cosmetic issue where the icons are able to extend past their sides... but it happens less often with the media-queries progressively scaling fonts and icons down.