### PR TITLE
Limited the number of documents in the collection viewer to 9500. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,15 +82,15 @@ See the section about [running tests](https://facebook.github.io/create-react-ap
 To run the test runner with emulators, use:
 
 ```bash
-firebase emulators:exec --project sample 'npm test'
+firebase emulators:exec --project demo-test 'npm test'
 
-firebase emulators:exec --project sample --only firestore 'npm test AddCollectionDialog.test.tsx'
+firebase emulators:exec --project demo-test --only firestore 'npm test AddCollectionDialog.test.tsx'
 ```
 
 To disable the Jest interactive mode use the flag `watchAll=false` like so:
 
 ```bash
-firebase emulators:exec --project sample --only firestore 'npm test -- --watchAll=false'
+firebase emulators:exec --project demo-test --only firestore 'npm test -- --watchAll=false'
 ```
 
 If you get port conflict errors, make sure to stop other instances of the Firebase Emulator Suite (e.g. the one you've started for the development server above) and try again.

--- a/src/components/Firestore/Collection.test.tsx
+++ b/src/components/Firestore/Collection.test.tsx
@@ -233,23 +233,27 @@ it('sorts documents when filtered', async () => {
   );
 });
 it('limits documents in a collection to specified value', async () => {
-    const { queryAllByText, findByText } = await renderWithFirestore(
-      async (firestore) => {
-        const collectionRef = collection(firestore, 'my-stuff');
-        await setDoc(doc(collectionRef, 'doc-z'), { foo: 'z' });
-        await setDoc(doc(collectionRef, 'doc-a'), { foo: 'a' });
-        await setDoc(doc(collectionRef, 'doc-b'), { foo: 'b' });
-  
-        return ( // Wrong props right?
-          <>
-            <Portal />
-            <Collection collection={collectionRef} maxFetchedDocumentsPerCollection={2} />
-          </>
-        );
-      }
-    );
+  const { queryAllByText, findByText } = await renderWithFirestore(
+    async (firestore) => {
+      const collectionRef = collection(firestore, 'my-stuff');
+      await setDoc(doc(collectionRef, 'doc-z'), { foo: 'z' });
+      await setDoc(doc(collectionRef, 'doc-a'), { foo: 'a' });
+      await setDoc(doc(collectionRef, 'doc-b'), { foo: 'b' });
+
+      return (
+        // Wrong props right?
+        <>
+          <Portal />
+          <Collection
+            collection={collectionRef}
+            maxFetchedDocumentsPerCollection={2}
+          />
+        </>
+      );
+    }
+  );
   await findByText(/doc-a/);
-  await findByText(/doc-b/); 
+  await findByText(/doc-b/);
   // The number of results is limited to 2 above, expect only a + b.
   expect(queryAllByText(/doc-a|doc-b|doc-z/).map((e) => e.textContent)).toEqual(
     ['doc-a', 'doc-b']

--- a/src/components/Firestore/Collection.test.tsx
+++ b/src/components/Firestore/Collection.test.tsx
@@ -232,6 +232,29 @@ it('sorts documents when filtered', async () => {
     ['doc-a', 'doc-b', 'doc-z']
   );
 });
+it('limits documents in a collection to specified value', async () => {
+    const { queryAllByText, findByText } = await renderWithFirestore(
+      async (firestore) => {
+        const collectionRef = collection(firestore, 'my-stuff');
+        await setDoc(doc(collectionRef, 'doc-z'), { foo: 'z' });
+        await setDoc(doc(collectionRef, 'doc-a'), { foo: 'a' });
+        await setDoc(doc(collectionRef, 'doc-b'), { foo: 'b' });
+  
+        return ( // Wrong props right?
+          <>
+            <Portal />
+            <Collection collection={collectionRef} maxFetchedDocumentsPerCollection={2} />
+          </>
+        );
+      }
+    );
+  await findByText(/doc-a/);
+  await findByText(/doc-b/); 
+  // The number of results is limited to 2 above, expect only a + b.
+  expect(queryAllByText(/doc-a|doc-b|doc-z/).map((e) => e.textContent)).toEqual(
+    ['doc-a', 'doc-b']
+  );
+});
 
 it('shows the missing documents', async () => {
   const { getByText, findByText } = await renderWithFirestore(

--- a/src/components/Firestore/Collection.tsx
+++ b/src/components/Firestore/Collection.tsx
@@ -32,7 +32,7 @@ import {
   query,
   setDoc,
   where,
-  limit,
+  limit
 } from 'firebase/firestore';
 import get from 'lodash.get';
 import React, { useEffect, useState } from 'react';

--- a/src/components/Firestore/Collection.tsx
+++ b/src/components/Firestore/Collection.tsx
@@ -32,7 +32,7 @@ import {
   query,
   setDoc,
   where,
-  limit
+  limit,
 } from 'firebase/firestore';
 import get from 'lodash.get';
 import React, { useEffect, useState } from 'react';
@@ -69,7 +69,7 @@ const NO_DOCS: QueryDocumentSnapshot<DocumentData>[] = [];
 
 export interface Props {
   collection: CollectionReference;
-  maxFetchedDocumentsPerCollection? : number;
+  maxFetchedDocumentsPerCollection?: number;
 }
 
 export function withCollectionState(
@@ -323,7 +323,11 @@ export function applyCollectionFilter(
       filteredCollection,
       // This is a short-term fix to address the webchannel queue limit of 10k.
       // See https://github.com/firebase/firebase-tools/issues/5197.
-      limit(maxFetchedDocumentsPerCollection ? maxFetchedDocumentsPerCollection : 9500)
+      limit(
+        maxFetchedDocumentsPerCollection
+          ? maxFetchedDocumentsPerCollection
+          : 9500
+      )
     );
   }
   return filteredCollection;

--- a/src/components/Firestore/Collection.tsx
+++ b/src/components/Firestore/Collection.tsx
@@ -32,6 +32,7 @@ import {
   query,
   setDoc,
   where,
+  limit
 } from 'firebase/firestore';
 import get from 'lodash.get';
 import React, { useEffect, useState } from 'react';
@@ -68,6 +69,7 @@ const NO_DOCS: QueryDocumentSnapshot<DocumentData>[] = [];
 
 export interface Props {
   collection: CollectionReference;
+  maxFetchedDocumentsPerCollection? : number;
 }
 
 export function withCollectionState(
@@ -75,12 +77,13 @@ export function withCollectionState(
     React.PropsWithChildren<CollectionPresentationProps>
   >
 ): React.ComponentType<React.PropsWithChildren<Props>> {
-  return ({ collection }) => {
+  return ({ collection, maxFetchedDocumentsPerCollection }) => {
     const [newDocumentId, setNewDocumentId] = useState<string>();
     const collectionFilter = useCollectionFilter(collection.path);
     const filteredCollection = applyCollectionFilter(
       collection,
-      collectionFilter
+      collectionFilter,
+      maxFetchedDocumentsPerCollection
     );
     const collectionSnapshot = useFirestoreCollection<{}>(filteredCollection, {
       suspense: true,
@@ -283,9 +286,10 @@ export const CollectionPresentation: React.FC<
   );
 };
 
-function applyCollectionFilter(
+export function applyCollectionFilter(
   collection: Query<DocumentData>,
-  collectionFilter?: CollectionFilterType
+  collectionFilter?: CollectionFilterType,
+  maxFetchedDocumentsPerCollection?: number
 ): Query<DocumentData> {
   let filteredCollection = collection;
   if (collectionFilter && isSingleValueCollectionFilter(collectionFilter)) {
@@ -312,6 +316,14 @@ function applyCollectionFilter(
     filteredCollection = query(
       filteredCollection,
       orderBy(collectionFilter.field, collectionFilter.sort)
+    );
+  }
+  if (filteredCollection) {
+    filteredCollection = query(
+      filteredCollection,
+      // This is a short-term fix to address the webchannel queue limit of 10k.
+      // See https://github.com/firebase/firebase-tools/issues/5197.
+      limit(maxFetchedDocumentsPerCollection ? maxFetchedDocumentsPerCollection : 9500)
     );
   }
   return filteredCollection;

--- a/src/components/Firestore/Collection.tsx
+++ b/src/components/Firestore/Collection.tsx
@@ -286,10 +286,10 @@ export const CollectionPresentation: React.FC<
   );
 };
 
-export function applyCollectionFilter(
+function applyCollectionFilter(
   collection: Query<DocumentData>,
   collectionFilter?: CollectionFilterType,
-  maxFetchedDocumentsPerCollection?: number
+  maxFetchedDocumentsPerCollection: number = 9500
 ): Query<DocumentData> {
   let filteredCollection = collection;
   if (collectionFilter && isSingleValueCollectionFilter(collectionFilter)) {
@@ -323,11 +323,7 @@ export function applyCollectionFilter(
       filteredCollection,
       // This is a short-term fix to address the webchannel queue limit of 10k.
       // See https://github.com/firebase/firebase-tools/issues/5197.
-      limit(
-        maxFetchedDocumentsPerCollection
-          ? maxFetchedDocumentsPerCollection
-          : 9500
-      )
+      limit(maxFetchedDocumentsPerCollection)
     );
   }
   return filteredCollection;


### PR DESCRIPTION
This is to resolve an issue where the Firestore emulator is hitting a 10k webchannel queue limit.

https://github.com/firebase/firebase-tools/issues/5197