### PR TITLE
Update PanelHeader.scss remove overflow property

### DIFF
--- a/src/components/Firestore/PanelHeader.scss
+++ b/src/components/Firestore/PanelHeader.scss
@@ -17,9 +17,6 @@
 @import '../common/utils';
 
 .Firestore-PanelHeader {
-  .CardActionBar {
-    overflow: visible;
-  }
   .CardActionBar-container {
     padding: 8px 12px;
     height: 44px;


### PR DESCRIPTION
Unnecessary space added due to the `overflow` property

![image](https://github.com/firebase/firebase-tools-ui/assets/5612477/6f8b5ae7-2dbf-4214-9223-b2816eeca10c)
