### PR TITLE
Fixed a a11y issue with the extensions page decorative icons being read.

### DIFF
--- a/src/components/Extensions/List/ExtensionsTable/ExtensionTableRow.module.scss
+++ b/src/components/Extensions/List/ExtensionsTable/ExtensionTableRow.module.scss
@@ -14,27 +14,6 @@
  * limitations under the License.
  */
 
-.extensionRow {
-  &:first-child {
-    border: 0 solid;
-  }
-
-  &:hover {
-    border-color: var(--fire-color-input-borders);
-  }
-
-  .manageButtonText {
-    visibility: hidden;
-  }
-
-  &:hover,
-  .manageButton:focus {
-    .manageButtonText {
-      visibility: visible;
-    }
-  }
-}
-
 .iconCell,
 .infoCell {
   padding: 8px 16px;

--- a/src/components/Extensions/List/ExtensionsTable/ExtensionTableRow.tsx
+++ b/src/components/Extensions/List/ExtensionsTable/ExtensionTableRow.tsx
@@ -73,7 +73,7 @@ export const ExtensionsTableRow: React.FC<
           }}
           className={styles.manageButton}
           label={<div className={styles.manageButtonText}>Manage</div>}
-          aria-label={'Manage, ' + extension.displayName}
+          aria-label={'Manage ' + extension.displayName}
         />
       </DataTableCell>
     </DataTableRow>

--- a/src/components/Extensions/List/ExtensionsTable/ExtensionTableRow.tsx
+++ b/src/components/Extensions/List/ExtensionsTable/ExtensionTableRow.tsx
@@ -73,7 +73,7 @@ export const ExtensionsTableRow: React.FC<
           }}
           className={styles.manageButton}
           label={<div className={styles.manageButtonText}>Manage</div>}
-          trailingIcon="arrow_forward"
+          aria-label={"Manage, " + extension.displayName}
         />
       </DataTableCell>
     </DataTableRow>

--- a/src/components/Extensions/List/ExtensionsTable/ExtensionTableRow.tsx
+++ b/src/components/Extensions/List/ExtensionsTable/ExtensionTableRow.tsx
@@ -73,7 +73,7 @@ export const ExtensionsTableRow: React.FC<
           }}
           className={styles.manageButton}
           label={<div className={styles.manageButtonText}>Manage</div>}
-          aria-label={"Manage, " + extension.displayName}
+          aria-label={'Manage, ' + extension.displayName}
         />
       </DataTableCell>
     </DataTableRow>

--- a/src/components/common/links/ExternalLink.tsx
+++ b/src/components/common/links/ExternalLink.tsx
@@ -33,7 +33,7 @@ export function ExternalLink(
       rel="noopener noreferrer"
     >
       <span className={styles.content}>{props.children}</span>
-      <Icon icon="open_in_new" className={styles.icon} />
+      <Icon aria-hidden="true" icon="open_in_new" className={styles.icon} />
     </a>
   );
 }


### PR DESCRIPTION
The icon itself is a built-in of the rmwc Button and so I made the button visible instead of visible-on-hover and removed the icon.

Internal bug: b/277826813.