### PR TITLE
Autofocus new input field elements as they occur on the screen

### DIFF
--- a/src/components/Firestore/DocumentEditor/index.tsx
+++ b/src/components/Firestore/DocumentEditor/index.tsx
@@ -436,6 +436,7 @@ const NameEditor: React.FC<
     <Field
       label="Field"
       outlined
+      autoFocus
       value={child.name}
       disabled={readonly}
       onChange={(e) => {


### PR DESCRIPTION
This is especially important for tab navigation where the add field button is below the list of fields. in the Add document dialog.

Addresses b/278641318.