### PR TITLE
A11y Bug Fix: Screenreader Announcement on `Clear All Data`

### DIFF
--- a/src/components/Auth/UsersCard/table/UsersCleared.module.scss
+++ b/src/components/Auth/UsersCard/table/UsersCleared.module.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/Auth/UsersCard/table/UsersCleared.module.scss
+++ b/src/components/Auth/UsersCard/table/UsersCleared.module.scss
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.visuallyHidden {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}

--- a/src/components/Auth/UsersCard/table/UsersCleared.test.tsx
+++ b/src/components/Auth/UsersCard/table/UsersCleared.test.tsx
@@ -17,11 +17,11 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 
-import UsersCleared from './UsersCleared';
+import { UsersCleared } from './UsersCleared';
 
 describe('UsersCleared', () => {
   it('renders header row when all users have been cleared from the table', () => {
-    const { getByRole } = render(<UsersCleared />);
+    const { getByRole } = render(<UsersCleared alertText="" />);
     expect(getByRole('alert')).not.toBeNull();
   });
 });

--- a/src/components/Auth/UsersCard/table/UsersCleared.test.tsx
+++ b/src/components/Auth/UsersCard/table/UsersCleared.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 
-import { UsersCleared } from './UsersCleared';
+import UsersCleared from './UsersCleared';
 
 describe('UsersCleared', () => {
   it('renders header row when all users have been cleared from the table', () => {

--- a/src/components/Auth/UsersCard/table/UsersCleared.test.tsx
+++ b/src/components/Auth/UsersCard/table/UsersCleared.test.tsx
@@ -22,6 +22,6 @@ import { UsersCleared } from './UsersCleared';
 describe('UsersCleared', () => {
   it('renders header row when all users have been cleared from the table', () => {
     const { getByText } = render(<UsersCleared />);
-    expect(getByText(/All users cleared/)).not.toBeNull();
+    expect(getByText('')).not.toBeNull();
   });
 });

--- a/src/components/Auth/UsersCard/table/UsersCleared.test.tsx
+++ b/src/components/Auth/UsersCard/table/UsersCleared.test.tsx
@@ -21,7 +21,7 @@ import { UsersCleared } from './UsersCleared';
 
 describe('UsersCleared', () => {
   it('renders header row when all users have been cleared from the table', () => {
-    const { getByText } = render(<UsersCleared />);
-    expect(getByText('')).not.toBeNull();
+    const { getByRole } = render(<UsersCleared />);
+    expect(getByRole('alert')).not.toBeNull();
   });
 });

--- a/src/components/Auth/UsersCard/table/UsersCleared.test.tsx
+++ b/src/components/Auth/UsersCard/table/UsersCleared.test.tsx
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { UsersCleared } from './UsersCleared';
+
+describe('UsersCleared', () => {
+  it('renders header row when all users have been cleared from the table', () => {
+    const { getByText } = render(<UsersCleared />);
+    expect(getByText(/All users cleared/)).not.toBeNull();
+  });
+});

--- a/src/components/Auth/UsersCard/table/UsersCleared.tsx
+++ b/src/components/Auth/UsersCard/table/UsersCleared.tsx
@@ -14,14 +14,32 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import styles from './UsersCleared.module.scss';
 
 export const UsersCleared: React.FC<React.PropsWithChildren<unknown>> = () => {
+  const DISPLAY_TIME_MS = 500;
+  const [alertText, setAlertText] = useState('');
+
+  const onUsersClearedEvent = () => {
+    setAlertText('All Users CLeared!');
+    setTimeout(() => {
+      setAlertText('');
+    }, DISPLAY_TIME_MS);
+  };
+
+  useEffect(() => {
+    window.addEventListener('usersCleared', onUsersClearedEvent);
+
+    return () => {
+      window.removeEventListener('usersCleared', onUsersClearedEvent);
+    };
+  }, []);
+
   return (
     <div className={styles.visuallyHidden} role="alert">
-      All users cleared!
+      {alertText}
     </div>
   );
 };

--- a/src/components/Auth/UsersCard/table/UsersCleared.tsx
+++ b/src/components/Auth/UsersCard/table/UsersCleared.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,22 @@ import styles from './UsersCleared.module.scss';
 
 export type UsersClearedProps = PropsFromStore;
 
+/**
+ *
+ * Renders a visibly hidden, but screenreader parseable, alert to
+ * inform the user that all users have been deleted after the
+ * `Clear All Data` button is pressed. The text rendered /
+ * spoken in the component is housed in the auth redux store's
+ * `alertText` field. Changing the value stored in this field triggers
+ * a re-render of this component, which will force a screenreader to
+ * read the new text. Thus, the value stored in `alertText` should only
+ * be 1. updated when you want the screen reader to alert the user of something,
+ * or 2. cleared to allow the screenreader to repeat a message (the text in
+ * `alertText` is only read by the screenreader when the value is updated).
+ *
+ * Examples of such updates / clears are available in src/store/auth/reducer.tsx
+ *
+ */
 export const UsersCleared: React.FC<
   React.PropsWithChildren<UsersClearedProps>
 > = ({ alertText }) => {

--- a/src/components/Auth/UsersCard/table/UsersCleared.tsx
+++ b/src/components/Auth/UsersCard/table/UsersCleared.tsx
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import styles from './UsersCleared.module.scss';
+
+export const UsersCleared: React.FC<React.PropsWithChildren<unknown>> = () => {
+  return (
+    <div className={styles.visuallyHidden} role="alert">
+      All users cleared!
+    </div>
+  );
+};

--- a/src/components/Auth/UsersCard/table/UsersCleared.tsx
+++ b/src/components/Auth/UsersCard/table/UsersCleared.tsx
@@ -14,32 +14,28 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useState } from 'react';
+import { connect } from 'react-redux';
 
+import { createStructuredSelector } from '../../../../store';
+import { getAlertText } from '../../../../store/auth/selectors';
 import styles from './UsersCleared.module.scss';
 
-export const UsersCleared: React.FC<React.PropsWithChildren<unknown>> = () => {
-  const DISPLAY_TIME_MS = 500;
-  const [alertText, setAlertText] = useState('');
+export type UsersClearedProps = PropsFromStore;
 
-  const onAllUsersClearedEvent = () => {
-    setAlertText('All Users CLeared!');
-    setTimeout(() => {
-      setAlertText('');
-    }, DISPLAY_TIME_MS);
-  };
-
-  useEffect(() => {
-    window.addEventListener('usersCleared', onAllUsersClearedEvent);
-
-    return () => {
-      window.removeEventListener('usersCleared', onAllUsersClearedEvent);
-    };
-  }, []);
-
+export const UsersCleared: React.FC<
+  React.PropsWithChildren<UsersClearedProps>
+> = ({ alertText }) => {
   return (
     <div className={styles.visuallyHidden} role="alert">
       {alertText}
     </div>
   );
 };
+
+export const mapStateToProps = createStructuredSelector({
+  alertText: getAlertText,
+});
+
+export type PropsFromStore = ReturnType<typeof mapStateToProps>;
+
+export default connect(mapStateToProps)(UsersCleared);

--- a/src/components/Auth/UsersCard/table/UsersCleared.tsx
+++ b/src/components/Auth/UsersCard/table/UsersCleared.tsx
@@ -22,7 +22,7 @@ export const UsersCleared: React.FC<React.PropsWithChildren<unknown>> = () => {
   const DISPLAY_TIME_MS = 500;
   const [alertText, setAlertText] = useState('');
 
-  const onUsersClearedEvent = () => {
+  const onAllUsersClearedEvent = () => {
     setAlertText('All Users CLeared!');
     setTimeout(() => {
       setAlertText('');
@@ -30,10 +30,10 @@ export const UsersCleared: React.FC<React.PropsWithChildren<unknown>> = () => {
   };
 
   useEffect(() => {
-    window.addEventListener('usersCleared', onUsersClearedEvent);
+    window.addEventListener('usersCleared', onAllUsersClearedEvent);
 
     return () => {
-      window.removeEventListener('usersCleared', onUsersClearedEvent);
+      window.removeEventListener('usersCleared', onAllUsersClearedEvent);
     };
   }, []);
 

--- a/src/components/Auth/UsersCard/table/UsersTable.tsx
+++ b/src/components/Auth/UsersCard/table/UsersTable.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/Auth/UsersCard/table/UsersTable.tsx
+++ b/src/components/Auth/UsersCard/table/UsersTable.tsx
@@ -36,10 +36,10 @@ import {
 } from '../../../../store/auth/actions';
 import {
   getFilteredUsers,
-  getShowNukedUsers,
   getShowTable,
   getShowZeroResults,
   getShowZeroState,
+  getUsersCleared,
 } from '../../../../store/auth/selectors';
 import { RemoteResult, createRemoteDataLoaded } from '../../../../store/utils';
 import { AuthUser } from '../../types';
@@ -132,7 +132,7 @@ export const UsersTable: React.FC<React.PropsWithChildren<UsersTableProps>> = ({
   openAuthUserDialog,
   shouldShowZeroResults,
   shouldShowZeroState,
-  shouldShowNukedUsers,
+  shouldShowUsersCleared,
 }) => {
   return (
     <>
@@ -172,7 +172,7 @@ export const UsersTable: React.FC<React.PropsWithChildren<UsersTableProps>> = ({
           </DataTableBody>
         </DataTableContent>
       </DataTable>
-      {shouldShowNukedUsers && <UsersCleared />}
+      {shouldShowUsersCleared && <UsersCleared />}
       {shouldShowZeroResults && <NoResults />}
       {shouldShowZeroState && <AuthZeroState />}
     </>
@@ -184,7 +184,7 @@ export const mapStateToProps = createStructuredSelector({
   shouldShowZeroResults: getShowZeroResults,
   shouldShowZeroState: getShowZeroState,
   filteredUsers: getFilteredUsers,
-  shouldShowNukedUsers: getShowNukedUsers,
+  shouldShowUsersCleared: getUsersCleared,
 });
 
 export type PropsFromStore = ReturnType<typeof mapStateToProps>;

--- a/src/components/Auth/UsersCard/table/UsersTable.tsx
+++ b/src/components/Auth/UsersCard/table/UsersTable.tsx
@@ -36,6 +36,7 @@ import {
 } from '../../../../store/auth/actions';
 import {
   getFilteredUsers,
+  getShowNukedUsers,
   getShowTable,
   getShowZeroResults,
   getShowZeroState,
@@ -46,6 +47,7 @@ import { AuthZeroState } from './AuthZeroState';
 import { confirmDeleteUser } from './confirmDeleteUser';
 import { NoResults } from './NoResults';
 import { ProviderCell } from './ProviderCell';
+import { UsersCleared } from './UsersCleared';
 import styles from './UsersTable.module.scss';
 
 export type UsersTableProps = PropsFromDispatch & PropsFromStore;
@@ -130,6 +132,7 @@ export const UsersTable: React.FC<React.PropsWithChildren<UsersTableProps>> = ({
   openAuthUserDialog,
   shouldShowZeroResults,
   shouldShowZeroState,
+  shouldShowNukedUsers,
 }) => {
   return (
     <>
@@ -169,6 +172,7 @@ export const UsersTable: React.FC<React.PropsWithChildren<UsersTableProps>> = ({
           </DataTableBody>
         </DataTableContent>
       </DataTable>
+      {shouldShowNukedUsers && <UsersCleared />}
       {shouldShowZeroResults && <NoResults />}
       {shouldShowZeroState && <AuthZeroState />}
     </>
@@ -180,6 +184,7 @@ export const mapStateToProps = createStructuredSelector({
   shouldShowZeroResults: getShowZeroResults,
   shouldShowZeroState: getShowZeroState,
   filteredUsers: getFilteredUsers,
+  shouldShowNukedUsers: getShowNukedUsers,
 });
 
 export type PropsFromStore = ReturnType<typeof mapStateToProps>;

--- a/src/components/Auth/UsersCard/table/UsersTable.tsx
+++ b/src/components/Auth/UsersCard/table/UsersTable.tsx
@@ -46,7 +46,7 @@ import { AuthZeroState } from './AuthZeroState';
 import { confirmDeleteUser } from './confirmDeleteUser';
 import { NoResults } from './NoResults';
 import { ProviderCell } from './ProviderCell';
-import { UsersCleared } from './UsersCleared';
+import UsersCleared from './UsersCleared';
 import styles from './UsersTable.module.scss';
 
 export type UsersTableProps = PropsFromDispatch & PropsFromStore;

--- a/src/components/Auth/UsersCard/table/UsersTable.tsx
+++ b/src/components/Auth/UsersCard/table/UsersTable.tsx
@@ -39,7 +39,6 @@ import {
   getShowTable,
   getShowZeroResults,
   getShowZeroState,
-  getUsersCleared,
 } from '../../../../store/auth/selectors';
 import { RemoteResult, createRemoteDataLoaded } from '../../../../store/utils';
 import { AuthUser } from '../../types';
@@ -132,7 +131,6 @@ export const UsersTable: React.FC<React.PropsWithChildren<UsersTableProps>> = ({
   openAuthUserDialog,
   shouldShowZeroResults,
   shouldShowZeroState,
-  shouldShowUsersCleared,
 }) => {
   return (
     <>
@@ -172,7 +170,7 @@ export const UsersTable: React.FC<React.PropsWithChildren<UsersTableProps>> = ({
           </DataTableBody>
         </DataTableContent>
       </DataTable>
-      {shouldShowUsersCleared && <UsersCleared />}
+      <UsersCleared />
       {shouldShowZeroResults && <NoResults />}
       {shouldShowZeroState && <AuthZeroState />}
     </>
@@ -184,7 +182,6 @@ export const mapStateToProps = createStructuredSelector({
   shouldShowZeroResults: getShowZeroResults,
   shouldShowZeroState: getShowZeroState,
   filteredUsers: getFilteredUsers,
-  shouldShowUsersCleared: getUsersCleared,
 });
 
 export type PropsFromStore = ReturnType<typeof mapStateToProps>;

--- a/src/components/Auth/test_utils.ts
+++ b/src/components/Auth/test_utils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/Auth/test_utils.ts
+++ b/src/components/Auth/test_utils.ts
@@ -27,7 +27,7 @@ export function getMockAuthStore(state?: Partial<AppState['auth']>) {
       filter: '',
       allowDuplicateEmails: false,
       tenants: { loading: false, result: { data: [] } },
-      justNukedUsers: false,
+      justClearedUsers: false,
       ...state,
     },
   });
@@ -65,7 +65,7 @@ export function createFakeState(state: Partial<AuthState>): AuthState {
     allowDuplicateEmails: true,
     users: createRemoteDataLoaded([]),
     tenants: createRemoteDataLoaded([]),
-    justNukedUsers: false,
+    justClearedUsers: false,
     ...state,
   };
 }
@@ -75,7 +75,7 @@ export function createFakeAuthStateWithUsers(users: AuthUser[]) {
 }
 
 export function createFakeAuthStateAfterClearingUsers() {
-  return createFakeState({ justNukedUsers: true });
+  return createFakeState({ justClearedUsers: true });
 }
 
 export function createFakeAuthStateWithTenants(tenants: Tenant[]) {

--- a/src/components/Auth/test_utils.ts
+++ b/src/components/Auth/test_utils.ts
@@ -28,6 +28,7 @@ export function getMockAuthStore(state?: Partial<AppState['auth']>) {
       allowDuplicateEmails: false,
       tenants: { loading: false, result: { data: [] } },
       ...state,
+      alertText: '',
     },
   });
 }
@@ -65,11 +66,16 @@ export function createFakeState(state: Partial<AuthState>): AuthState {
     users: createRemoteDataLoaded([]),
     tenants: createRemoteDataLoaded([]),
     ...state,
+    alertText: '',
   };
 }
 
 export function createFakeAuthStateWithUsers(users: AuthUser[]) {
   return createFakeState({ users: createRemoteDataLoaded(users) });
+}
+
+export function createFakeAuthStateWithAllDataCleared() {
+  return createFakeState({ alertText: 'All Users Cleared!' });
 }
 
 export function createFakeAuthStateWithTenants(tenants: Tenant[]) {

--- a/src/components/Auth/test_utils.ts
+++ b/src/components/Auth/test_utils.ts
@@ -27,6 +27,7 @@ export function getMockAuthStore(state?: Partial<AppState['auth']>) {
       filter: '',
       allowDuplicateEmails: false,
       tenants: { loading: false, result: { data: [] } },
+      justNukedUsers: false,
       ...state,
     },
   });
@@ -64,6 +65,7 @@ export function createFakeState(state: Partial<AuthState>): AuthState {
     allowDuplicateEmails: true,
     users: createRemoteDataLoaded([]),
     tenants: createRemoteDataLoaded([]),
+    justNukedUsers: false,
     ...state,
   };
 }

--- a/src/components/Auth/test_utils.ts
+++ b/src/components/Auth/test_utils.ts
@@ -75,10 +75,7 @@ export function createFakeAuthStateWithUsers(users: AuthUser[]) {
 }
 
 export function createFakeAuthStateWithAllDataCleared() {
-  return createFakeState({
-    users: createRemoteDataLoaded([]),
-    alertText: 'All Users Cleared!',
-  });
+  return createFakeState({ alertText: 'All Users Cleared!' });
 }
 
 export function createFakeAuthStateWithTenants(tenants: Tenant[]) {

--- a/src/components/Auth/test_utils.ts
+++ b/src/components/Auth/test_utils.ts
@@ -75,7 +75,10 @@ export function createFakeAuthStateWithUsers(users: AuthUser[]) {
 }
 
 export function createFakeAuthStateWithAllDataCleared() {
-  return createFakeState({ alertText: 'All Users Cleared!' });
+  return createFakeState({
+    users: createRemoteDataLoaded([]),
+    alertText: 'All Users Cleared!',
+  });
 }
 
 export function createFakeAuthStateWithTenants(tenants: Tenant[]) {

--- a/src/components/Auth/test_utils.ts
+++ b/src/components/Auth/test_utils.ts
@@ -65,8 +65,8 @@ export function createFakeState(state: Partial<AuthState>): AuthState {
     allowDuplicateEmails: true,
     users: createRemoteDataLoaded([]),
     tenants: createRemoteDataLoaded([]),
-    ...state,
     alertText: '',
+    ...state,
   };
 }
 

--- a/src/components/Auth/test_utils.ts
+++ b/src/components/Auth/test_utils.ts
@@ -74,6 +74,10 @@ export function createFakeAuthStateWithUsers(users: AuthUser[]) {
   return createFakeState({ users: createRemoteDataLoaded(users) });
 }
 
+export function createFakeAuthStateAfterClearingUsers() {
+  return createFakeState({ justNukedUsers: true });
+}
+
 export function createFakeAuthStateWithTenants(tenants: Tenant[]) {
   return createFakeState({ tenants: createRemoteDataLoaded(tenants) });
 }

--- a/src/components/Auth/test_utils.ts
+++ b/src/components/Auth/test_utils.ts
@@ -27,7 +27,6 @@ export function getMockAuthStore(state?: Partial<AppState['auth']>) {
       filter: '',
       allowDuplicateEmails: false,
       tenants: { loading: false, result: { data: [] } },
-      justClearedUsers: false,
       ...state,
     },
   });
@@ -65,17 +64,12 @@ export function createFakeState(state: Partial<AuthState>): AuthState {
     allowDuplicateEmails: true,
     users: createRemoteDataLoaded([]),
     tenants: createRemoteDataLoaded([]),
-    justClearedUsers: false,
     ...state,
   };
 }
 
 export function createFakeAuthStateWithUsers(users: AuthUser[]) {
   return createFakeState({ users: createRemoteDataLoaded(users) });
-}
-
-export function createFakeAuthStateAfterClearingUsers() {
-  return createFakeState({ justClearedUsers: true });
 }
 
 export function createFakeAuthStateWithTenants(tenants: Tenant[]) {

--- a/src/components/Auth/types.ts
+++ b/src/components/Auth/types.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/Auth/types.ts
+++ b/src/components/Auth/types.ts
@@ -105,6 +105,7 @@ export interface AuthState {
   filter: string;
   allowDuplicateEmails: boolean;
   tenants: RemoteResult<Tenant[]>;
+  alertText: string;
 }
 
 // Similar the emulator config object of the same name in the Firebase CLI,

--- a/src/components/Auth/types.ts
+++ b/src/components/Auth/types.ts
@@ -105,7 +105,7 @@ export interface AuthState {
   filter: string;
   allowDuplicateEmails: boolean;
   tenants: RemoteResult<Tenant[]>;
-  justNukedUsers: boolean;
+  justClearedUsers: boolean;
 }
 
 // Similar the emulator config object of the same name in the Firebase CLI,

--- a/src/components/Auth/types.ts
+++ b/src/components/Auth/types.ts
@@ -105,6 +105,7 @@ export interface AuthState {
   filter: string;
   allowDuplicateEmails: boolean;
   tenants: RemoteResult<Tenant[]>;
+  justNukedUsers: boolean;
 }
 
 // Similar the emulator config object of the same name in the Firebase CLI,

--- a/src/components/Auth/types.ts
+++ b/src/components/Auth/types.ts
@@ -105,7 +105,6 @@ export interface AuthState {
   filter: string;
   allowDuplicateEmails: boolean;
   tenants: RemoteResult<Tenant[]>;
-  justClearedUsers: boolean;
 }
 
 // Similar the emulator config object of the same name in the Firebase CLI,

--- a/src/store/auth/reducer.test.ts
+++ b/src/store/auth/reducer.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/store/auth/reducer.test.ts
+++ b/src/store/auth/reducer.test.ts
@@ -15,7 +15,6 @@
  */
 
 import {
-  createFakeAuthStateAfterClearingUsers,
   createFakeAuthStateWithUsers,
   createFakeState,
   createFakeTenant,
@@ -63,7 +62,7 @@ describe('auth reducers', () => {
       const state = createFakeAuthStateWithUsers([user, user2]);
       const action = nukeUsersSuccess();
 
-      const expected = createFakeAuthStateAfterClearingUsers();
+      const expected = createFakeAuthStateWithUsers([]);
       expect(authReducer(state, action)).toEqual(expected);
     });
 

--- a/src/store/auth/reducer.test.ts
+++ b/src/store/auth/reducer.test.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  createFakeAuthStateAfterClearingUsers,
   createFakeAuthStateWithUsers,
   createFakeState,
   createFakeTenant,
@@ -62,7 +63,7 @@ describe('auth reducers', () => {
       const state = createFakeAuthStateWithUsers([user, user2]);
       const action = nukeUsersSuccess();
 
-      const expected = createFakeAuthStateWithUsers([]);
+      const expected = createFakeAuthStateAfterClearingUsers();
       expect(authReducer(state, action)).toEqual(expected);
     });
 

--- a/src/store/auth/reducer.test.ts
+++ b/src/store/auth/reducer.test.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  createFakeAuthStateWithAllDataCleared,
   createFakeAuthStateWithUsers,
   createFakeState,
   createFakeTenant,
@@ -62,7 +63,7 @@ describe('auth reducers', () => {
       const state = createFakeAuthStateWithUsers([user, user2]);
       const action = nukeUsersSuccess();
 
-      const expected = createFakeAuthStateWithUsers([]);
+      const expected = createFakeAuthStateWithAllDataCleared();
       expect(authReducer(state, action)).toEqual(expected);
     });
 

--- a/src/store/auth/reducer.tsx
+++ b/src/store/auth/reducer.tsx
@@ -36,7 +36,6 @@ export const authReducer = createReducer<AuthState, Action>(INIT_STATE)
         ...users,
         payload.user,
       ]);
-      draft.justClearedUsers = false;
     });
   })
   .handleAction(authActions.updateUserSuccess, (state, { payload }) => {
@@ -49,15 +48,15 @@ export const authReducer = createReducer<AuthState, Action>(INIT_STATE)
     });
   })
   .handleAction(authActions.nukeUsersSuccess, (state) => {
+    const alertUsersCleared = new Event('usersCleared');
+    window.dispatchEvent(alertUsersCleared);
     return produce(state, (draft) => {
       draft.users = mapResult(draft.users, () => []);
-      draft.justClearedUsers = true;
     });
   })
   .handleAction(authActions.nukeUsersForAllTenantsSuccess, (state) => {
     return produce(state, (draft) => {
       draft.users = mapResult(draft.users, () => []);
-      draft.justClearedUsers = true;
     });
   })
   .handleAction(
@@ -121,7 +120,6 @@ export const authReducer = createReducer<AuthState, Action>(INIT_STATE)
         loading: false,
         result: { data: payload },
       };
-      draft.justClearedUsers = false;
     });
   })
   .handleAction(authActions.authFetchUsersError, (state, { payload }) => {

--- a/src/store/auth/reducer.tsx
+++ b/src/store/auth/reducer.tsx
@@ -26,7 +26,7 @@ const INIT_STATE = {
   filter: '',
   allowDuplicateEmails: false,
   tenants: { loading: true },
-  justClearedUsers: false,
+  alertText: '',
 };
 
 export const authReducer = createReducer<AuthState, Action>(INIT_STATE)
@@ -36,6 +36,7 @@ export const authReducer = createReducer<AuthState, Action>(INIT_STATE)
         ...users,
         payload.user,
       ]);
+      draft.alertText = ''; // Maybe have an alert for "User Created"?
     });
   })
   .handleAction(authActions.updateUserSuccess, (state, { payload }) => {
@@ -48,15 +49,15 @@ export const authReducer = createReducer<AuthState, Action>(INIT_STATE)
     });
   })
   .handleAction(authActions.nukeUsersSuccess, (state) => {
-    const alertUsersCleared = new Event('usersCleared');
-    window.dispatchEvent(alertUsersCleared);
     return produce(state, (draft) => {
       draft.users = mapResult(draft.users, () => []);
+      draft.alertText = 'All Users Cleared!';
     });
   })
   .handleAction(authActions.nukeUsersForAllTenantsSuccess, (state) => {
     return produce(state, (draft) => {
       draft.users = mapResult(draft.users, () => []);
+      draft.alertText = 'All Users Cleared!';
     });
   })
   .handleAction(
@@ -120,6 +121,7 @@ export const authReducer = createReducer<AuthState, Action>(INIT_STATE)
         loading: false,
         result: { data: payload },
       };
+      draft.alertText = '';
     });
   })
   .handleAction(authActions.authFetchUsersError, (state, { payload }) => {

--- a/src/store/auth/reducer.tsx
+++ b/src/store/auth/reducer.tsx
@@ -26,7 +26,7 @@ const INIT_STATE = {
   filter: '',
   allowDuplicateEmails: false,
   tenants: { loading: true },
-  justNukedUsers: false,
+  justClearedUsers: false,
 };
 
 export const authReducer = createReducer<AuthState, Action>(INIT_STATE)
@@ -36,7 +36,7 @@ export const authReducer = createReducer<AuthState, Action>(INIT_STATE)
         ...users,
         payload.user,
       ]);
-      draft.justNukedUsers = false;
+      draft.justClearedUsers = false;
     });
   })
   .handleAction(authActions.updateUserSuccess, (state, { payload }) => {
@@ -51,13 +51,13 @@ export const authReducer = createReducer<AuthState, Action>(INIT_STATE)
   .handleAction(authActions.nukeUsersSuccess, (state) => {
     return produce(state, (draft) => {
       draft.users = mapResult(draft.users, () => []);
-      draft.justNukedUsers = true;
+      draft.justClearedUsers = true;
     });
   })
   .handleAction(authActions.nukeUsersForAllTenantsSuccess, (state) => {
     return produce(state, (draft) => {
       draft.users = mapResult(draft.users, () => []);
-      draft.justNukedUsers = true;
+      draft.justClearedUsers = true;
     });
   })
   .handleAction(
@@ -121,7 +121,7 @@ export const authReducer = createReducer<AuthState, Action>(INIT_STATE)
         loading: false,
         result: { data: payload },
       };
-      draft.justNukedUsers = false;
+      draft.justClearedUsers = false;
     });
   })
   .handleAction(authActions.authFetchUsersError, (state, { payload }) => {

--- a/src/store/auth/reducer.tsx
+++ b/src/store/auth/reducer.tsx
@@ -36,7 +36,7 @@ export const authReducer = createReducer<AuthState, Action>(INIT_STATE)
         ...users,
         payload.user,
       ]);
-      draft.alertText = ''; // Maybe have an alert for "User Created"?
+      draft.alertText = '';
     });
   })
   .handleAction(authActions.updateUserSuccess, (state, { payload }) => {

--- a/src/store/auth/reducer.tsx
+++ b/src/store/auth/reducer.tsx
@@ -26,6 +26,7 @@ const INIT_STATE = {
   filter: '',
   allowDuplicateEmails: false,
   tenants: { loading: true },
+  justNukedUsers: false,
 };
 
 export const authReducer = createReducer<AuthState, Action>(INIT_STATE)
@@ -35,6 +36,7 @@ export const authReducer = createReducer<AuthState, Action>(INIT_STATE)
         ...users,
         payload.user,
       ]);
+      draft.justNukedUsers = false;
     });
   })
   .handleAction(authActions.updateUserSuccess, (state, { payload }) => {
@@ -49,11 +51,13 @@ export const authReducer = createReducer<AuthState, Action>(INIT_STATE)
   .handleAction(authActions.nukeUsersSuccess, (state) => {
     return produce(state, (draft) => {
       draft.users = mapResult(draft.users, () => []);
+      draft.justNukedUsers = true;
     });
   })
   .handleAction(authActions.nukeUsersForAllTenantsSuccess, (state) => {
     return produce(state, (draft) => {
       draft.users = mapResult(draft.users, () => []);
+      draft.justNukedUsers = true;
     });
   })
   .handleAction(
@@ -117,6 +121,7 @@ export const authReducer = createReducer<AuthState, Action>(INIT_STATE)
         loading: false,
         result: { data: payload },
       };
+      draft.justNukedUsers = false;
     });
   })
   .handleAction(authActions.authFetchUsersError, (state, { payload }) => {

--- a/src/store/auth/reducer.tsx
+++ b/src/store/auth/reducer.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ export const authReducer = createReducer<AuthState, Action>(INIT_STATE)
         ...users,
         payload.user,
       ]);
-      draft.alertText = '';
+      draft.alertText = ''; // TODO(abradham): Consider alerting on "User Created"
     });
   })
   .handleAction(authActions.updateUserSuccess, (state, { payload }) => {

--- a/src/store/auth/selectors.ts
+++ b/src/store/auth/selectors.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/store/auth/selectors.ts
+++ b/src/store/auth/selectors.ts
@@ -109,10 +109,6 @@ export const getShowZeroResults = createSelector(
   getFilteredUsers,
   (users, filteredUsers) => users.length > 0 && filteredUsers.length === 0
 );
-export const getUsersCleared = createSelector(
-  getAuth,
-  (state: AuthState) => state.justClearedUsers
-);
 export const getShowTable = createSelector(
   getFilteredUsers,
   (filteredUsers) => filteredUsers.length > 0

--- a/src/store/auth/selectors.ts
+++ b/src/store/auth/selectors.ts
@@ -109,6 +109,10 @@ export const getShowZeroResults = createSelector(
   getFilteredUsers,
   (users, filteredUsers) => users.length > 0 && filteredUsers.length === 0
 );
+export const getAlertText = createSelector(
+  getAuth,
+  (state: AuthState) => state.alertText
+);
 export const getShowTable = createSelector(
   getFilteredUsers,
   (filteredUsers) => filteredUsers.length > 0

--- a/src/store/auth/selectors.ts
+++ b/src/store/auth/selectors.ts
@@ -109,9 +109,9 @@ export const getShowZeroResults = createSelector(
   getFilteredUsers,
   (users, filteredUsers) => users.length > 0 && filteredUsers.length === 0
 );
-export const getShowNukedUsers = createSelector(
+export const getUsersCleared = createSelector(
   getAuth,
-  (state: AuthState) => state.justNukedUsers
+  (state: AuthState) => state.justClearedUsers
 );
 export const getShowTable = createSelector(
   getFilteredUsers,

--- a/src/store/auth/selectors.ts
+++ b/src/store/auth/selectors.ts
@@ -109,6 +109,10 @@ export const getShowZeroResults = createSelector(
   getFilteredUsers,
   (users, filteredUsers) => users.length > 0 && filteredUsers.length === 0
 );
+export const getShowNukedUsers = createSelector(
+  getAuth,
+  (state: AuthState) => state.justNukedUsers
+);
 export const getShowTable = createSelector(
   getFilteredUsers,
   (filteredUsers) => filteredUsers.length > 0


### PR DESCRIPTION
Fixed an accessibility bug where screen readers wouldn't report that all users had been cleared from the table after the `Clear All Data` button on the `Authentication` screen was pressed.

Fixed by adding a [visually hidden](https://www.a11yproject.com/posts/how-to-hide-content/) [aria alert](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role) that notifies screen readers without changing the UI.

This change also required the addition of a new field to the `AuthState` redux store.