### PR TITLE
A11y Bug Fix: Auth User Table Dropdown Context

### DIFF
--- a/src/components/Auth/UsersCard/table/UsersTable.test.tsx
+++ b/src/components/Auth/UsersCard/table/UsersTable.test.tsx
@@ -113,7 +113,7 @@ describe('UserTable', () => {
         filteredUsers: [fakeUser1, fakeUser2],
       });
 
-      const menu = result.getAllByLabelText('Open menu')[0];
+      const menu = result.getAllByRole('menu')[0];
 
       await act(async () => {
         fireEvent.click(menu);

--- a/src/components/Auth/UsersCard/table/UsersTable.tsx
+++ b/src/components/Auth/UsersCard/table/UsersTable.tsx
@@ -91,7 +91,8 @@ export const UsersTableRow: React.FC<
             <IconButton
               theme="secondary"
               icon="more_vert"
-              label={`Open menu for user ${
+              label="Open menu"
+              aria-label={`Open menu for user ${
                 user.displayName || user.email || user.phoneNumber
               }`}
             />

--- a/src/components/Auth/UsersCard/table/UsersTable.tsx
+++ b/src/components/Auth/UsersCard/table/UsersTable.tsx
@@ -91,7 +91,7 @@ export const UsersTableRow: React.FC<
             <IconButton
               theme="secondary"
               icon="more_vert"
-              label={`Open menu for ${
+              label={`Open menu for user ${
                 user.displayName || user.email || user.phoneNumber
               }`}
             />

--- a/src/components/Auth/UsersCard/table/UsersTable.tsx
+++ b/src/components/Auth/UsersCard/table/UsersTable.tsx
@@ -91,10 +91,10 @@ export const UsersTableRow: React.FC<
             <IconButton
               theme="secondary"
               icon="more_vert"
-              label="Open menu"
               aria-label={`Open menu for user ${
                 user.displayName || user.email || user.phoneNumber
               }`}
+              role="menu"
             />
           }
           renderToPortal

--- a/src/components/Auth/UsersCard/table/UsersTable.tsx
+++ b/src/components/Auth/UsersCard/table/UsersTable.tsx
@@ -92,7 +92,9 @@ export const UsersTableRow: React.FC<
               theme="secondary"
               icon="more_vert"
               aria-label={`Open menu for user ${
-                user.displayName || user.email || user.phoneNumber
+                user.displayName ||
+                user.email ||
+                `with phone number ` + user.phoneNumber
               }`}
               role="menu"
             />

--- a/src/components/Auth/UsersCard/table/UsersTable.tsx
+++ b/src/components/Auth/UsersCard/table/UsersTable.tsx
@@ -88,7 +88,13 @@ export const UsersTableRow: React.FC<
           onOpen={() => setMenuOpen(true)}
           onClose={() => setMenuOpen(false)}
           handle={
-            <IconButton theme="secondary" icon="more_vert" label="Open menu" />
+            <IconButton
+              theme="secondary"
+              icon="more_vert"
+              label={`Open menu for ${
+                user.displayName || user.email || user.phoneNumber
+              }`}
+            />
           }
           renderToPortal
         >


### PR DESCRIPTION
Addresses b/262062452.

Adds context to dropdown menu for Editing, Deleting, or Disabling users on the Authentication `Users` table. With this change, either the `displayName`, `email`, or `phoneNumber` (one of these must exist for a user to be created in the table) of the user is read by the screenreader so that users of this assistive technology will know which user is being edited/disabled/deleted.