### PR TITLE
A11y Bug Fix: Firestore delete document field dialog

### DIFF
--- a/src/components/Firestore/DocumentPreview/FieldPreview.tsx
+++ b/src/components/Firestore/DocumentPreview/FieldPreview.tsx
@@ -24,6 +24,7 @@ import classnames from 'classnames';
 import { DocumentReference } from 'firebase/firestore';
 import React, { useCallback, useState } from 'react';
 
+import { promptDeleteDocumentSingleField } from '../dialogs/deleteDocumentSingleField';
 import { supportsEditing } from '../DocumentEditor';
 import { FirestoreArray } from '../models';
 import {
@@ -139,6 +140,12 @@ export const EditableFieldPreview: React.FC<
     [documentRef]
   );
 
+  async function handleDeleteField() {
+    const shouldDeleteField = await promptDeleteDocumentSingleField();
+    if (!shouldDeleteField) return;
+    deleteField(documentRef, documentData, path);
+  }
+
   return isEditing ? (
     <>
       {isArray(parentState) && (
@@ -207,7 +214,7 @@ export const EditableFieldPreview: React.FC<
             label="Remove field"
             onClick={(e) => {
               e.stopPropagation();
-              deleteField(documentRef, documentData, path);
+              handleDeleteField();
             }}
           />
         </>

--- a/src/components/Firestore/dialogs/deleteDocumentSingleField.tsx
+++ b/src/components/Firestore/dialogs/deleteDocumentSingleField.tsx
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DialogButton } from '@rmwc/dialog';
+
+import { Callout } from '../../common/Callout';
+import { confirm } from '../../common/DialogQueue';
+
+export const promptDeleteDocumentSingleField = () =>
+  confirm({
+    title: 'Delete data',
+    body: (
+      <div className="Firestore--dialog-body">
+        <Callout aside type="warning">
+          This will delete the selected field.
+        </Callout>
+      </div>
+    ),
+    // hide standard buttons so as to use `danger` button
+    acceptLabel: null,
+    cancelLabel: null,
+    footer: (
+      <>
+        <DialogButton action="close" type="button" theme="secondary">
+          Cancel
+        </DialogButton>
+        <DialogButton unelevated action="accept" isDefaultAction danger>
+          Delete
+        </DialogButton>
+      </>
+    ),
+  });


### PR DESCRIPTION
Addresses bug b/262062132.

Adds a confirmation dialog when the user tries to delete a document field in the firestore database ui.