### PR TITLE
A11y Bugfix: Add confirmation dialog on deleting `1..n` selected items from storage

### DIFF
--- a/src/components/Storage/Card/Table/Header/ActionHeader/ActionHeader.tsx
+++ b/src/components/Storage/Card/Table/Header/ActionHeader/ActionHeader.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import { useStorageFiles } from '../../../../api/useStorageFiles';
 import { UseMultiselectResult } from '../../../../common/useMultiselect';
 import { StorageItem } from '../../../../types';
 import styles from './ActionHeader.module.scss';
+import { confirmDeleteSelectedFiles } from './confirmDeleteSelectedFiles';
 
 interface ActionHeaderProps {
   selection: UseMultiselectResult;
@@ -75,9 +76,11 @@ export const ActionHeader: React.FC<
               Open all files
             </Button>
             <Button
-              onClick={() => {
-                selection.clearAll();
-                return deleteFiles(paths);
+              onClick={async () => {
+                if (await confirmDeleteSelectedFiles()) {
+                  selection.clearAll();
+                  return deleteFiles(paths);
+                }
               }}
               className={styles.deleteButton}
               outlined

--- a/src/components/Storage/Card/Table/Header/ActionHeader/confirmDeleteSelectedFiles.tsx
+++ b/src/components/Storage/Card/Table/Header/ActionHeader/confirmDeleteSelectedFiles.tsx
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DialogButton } from '@rmwc/dialog';
+import React from 'react';
+
+import { Callout } from '../../../../../common/Callout';
+import { confirm } from '../../../../../common/DialogQueue';
+
+export const confirmDeleteSelectedFiles = () => {
+  return confirm({
+    title: 'Delete selected files?',
+    body: (
+      <div className="Firestore--dialog-body">
+        <Callout aside type="warning">
+          This will delete all selected files.
+        </Callout>
+      </div>
+    ),
+    // hide standard buttons so as to use `danger` button
+    acceptLabel: null,
+    cancelLabel: null,
+    footer: (
+      <>
+        <DialogButton action="close" type="button" theme="secondary">
+          Cancel
+        </DialogButton>
+        <DialogButton unelevated action="accept" isDefaultAction danger>
+          Delete
+        </DialogButton>
+      </>
+    ),
+  });
+};


### PR DESCRIPTION
Adds a confirmation dialog when a user attempts to delete `n` files from storage. Matches behavior of https://github.com/firebase/firebase-tools-ui/pull/962.
 
Internal: Addresses b/263429461