### PR TITLE
A11y Bug Fix: RTDB root deletion confirmation

### DIFF
--- a/src/components/Database/DataViewer/NodeActions.tsx
+++ b/src/components/Database/DataViewer/NodeActions.tsx
@@ -118,6 +118,24 @@ export const NodeActions = React.memo<Props>(function NodeActions$({
     [realtimeRef, queryParams]
   );
 
+  const menuItems = [
+    {
+      icon: 'delete',
+      onlyRenderOnNonRoot: false,
+      name: 'Remove',
+    },
+    {
+      icon: 'file_copy',
+      onlyRenderOnNonRoot: true,
+      name: 'Clone',
+    },
+    {
+      icon: 'edit',
+      onlyRenderOnNonRoot: true,
+      name: 'Rename',
+    },
+  ];
+
   return (
     <aside className={'NodeActions' + (isActive ? ' NodeActions--active' : '')}>
       <Tooltip content="Filter children">
@@ -153,38 +171,30 @@ export const NodeActions = React.memo<Props>(function NodeActions$({
         onOpen={() => setMenuOpen(true)}
         onClose={() => setMenuOpen(false)}
         onSelect={async (evt) => {
-          const DELETE_IDX = 0;
-          const CLONE_IDX = 1;
-          const RENAME_IDX = 2;
-
-          switch (evt.detail.index) {
-            case DELETE_IDX:
+          switch (menuItems[evt.detail.index].name) {
+            case 'Remove':
               if (!isRoot || (await confirmDeleteRootDialog())) removeNode();
               break;
-
-            case CLONE_IDX:
+            case 'Clone':
               setCloneDialogIsOpen(true);
               break;
-
-            case RENAME_IDX:
+            case 'Rename':
               setRenameDialogIsOpen(true);
-              break;
           }
         }}
       >
-        <MenuItem>
-          <Icon icon="delete" /> Remove
-        </MenuItem>
-        {!isRoot && (
-          <MenuItem>
-            <Icon icon="file_copy" /> Clone
-          </MenuItem>
-        )}
-        {!isRoot && (
-          <MenuItem>
-            <Icon icon="edit" /> Rename
-          </MenuItem>
-        )}
+        {menuItems.map((item) => {
+          const shouldRender = !isRoot || !item.onlyRenderOnNonRoot;
+          if (shouldRender) {
+            return (
+              <MenuItem>
+                <Icon icon={item.icon} /> {item.name}
+              </MenuItem>
+            );
+          } else {
+            return <></>;
+          }
+        })}
       </SimpleMenu>
 
       {/* Extra UI that shows when actions are triggered */}

--- a/src/components/Database/DataViewer/NodeActions.tsx
+++ b/src/components/Database/DataViewer/NodeActions.tsx
@@ -31,6 +31,7 @@ import {
   DEFAULT_QUERY_PARAMS,
   QueryParams,
 } from './common/view_model';
+import { confirmDeleteRootDialog } from './confirmDeleteRootDialog';
 import { InlineQuery } from './InlineQuery';
 import { RenameDialog } from './RenameDialog';
 
@@ -151,17 +152,36 @@ export const NodeActions = React.memo<Props>(function NodeActions$({
         handle={<IconButton icon="more_vert" label="More options" />}
         onOpen={() => setMenuOpen(true)}
         onClose={() => setMenuOpen(false)}
+        onSelect={async (evt) => {
+          const DELETE_IDX = 0;
+          const CLONE_IDX = 1;
+          const RENAME_IDX = 2;
+
+          switch (evt.detail.index) {
+            case DELETE_IDX:
+              if (!isRoot || (await confirmDeleteRootDialog())) removeNode();
+              break;
+
+            case CLONE_IDX:
+              setCloneDialogIsOpen(true);
+              break;
+
+            case RENAME_IDX:
+              setRenameDialogIsOpen(true);
+              break;
+          }
+        }}
       >
-        <MenuItem onClick={removeNode}>
+        <MenuItem>
           <Icon icon="delete" /> Remove
         </MenuItem>
         {!isRoot && (
-          <MenuItem onClick={() => setCloneDialogIsOpen(true)}>
+          <MenuItem>
             <Icon icon="file_copy" /> Clone
           </MenuItem>
         )}
         {!isRoot && (
-          <MenuItem onClick={() => setRenameDialogIsOpen(true)}>
+          <MenuItem>
             <Icon icon="edit" /> Rename
           </MenuItem>
         )}

--- a/src/components/Database/DataViewer/confirmDeleteRootDialog.tsx
+++ b/src/components/Database/DataViewer/confirmDeleteRootDialog.tsx
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DialogButton } from '@rmwc/dialog';
+import React from 'react';
+
+import { Callout } from '../../common/Callout';
+import { confirm } from '../../common/DialogQueue';
+
+export const confirmDeleteRootDialog = () => {
+  return confirm({
+    title: 'Delete root object?',
+    body: (
+      <div className="Firestore--dialog-body">
+        <Callout aside type="warning">
+          This will delete all fields and sub-objects of this root from the
+          database.
+        </Callout>
+      </div>
+    ),
+    // hide standard buttons so as to use `danger` button
+    acceptLabel: null,
+    cancelLabel: null,
+    footer: (
+      <>
+        <DialogButton action="close" type="button" theme="secondary">
+          Cancel
+        </DialogButton>
+        <DialogButton unelevated action="accept" isDefaultAction danger>
+          Delete
+        </DialogButton>
+      </>
+    ),
+  });
+};


### PR DESCRIPTION
Adds a confirmation prompt when a user tries to delete a root JSON element on the RTDB page. In order to have the `remove`, `delete`, and `edit` options selectable by screen reader users, this fix required changing the behavior of the `MenuItem` and `SimpleMenu` components to respond to the `onSelect` event as opposed to the `onClick` event that was present before.

Internal: Addresses b/263429180