### PR TITLE
A11y Bug Fix: Firestore `Delete Document` / `Delete All Fields` from tab focus

### DIFF
--- a/src/components/Firestore/Document.tsx
+++ b/src/components/Firestore/Document.tsx
@@ -131,11 +131,22 @@ export const Document: React.FC<
         <SimpleMenu
           handle={<IconButton icon="more_vert" label="Menu" />}
           renderToPortal
+          onSelect={(evt) => {
+            const DELETE_DOC_IDX = 0;
+            const DELETE_ALL_FIELDS_IDX = 1;
+            switch (evt.detail.index) {
+              case DELETE_DOC_IDX:
+                setDeleteDocumentDialogOpen(true);
+                break;
+
+              case DELETE_ALL_FIELDS_IDX:
+                handleDeleteFields();
+                break;
+            }
+          }}
         >
-          <MenuItem onClick={() => setDeleteDocumentDialogOpen(true)}>
-            Delete document
-          </MenuItem>
-          <MenuItem onClick={handleDeleteFields}>Delete all fields</MenuItem>
+          <MenuItem>Delete document</MenuItem>
+          <MenuItem>Delete all fields</MenuItem>
         </SimpleMenu>
       </PanelHeader>
 


### PR DESCRIPTION
Enables the `Delete Document` and `Delete All Fields` menu buttons to be clickable via users of screen readers. Like [an earlier PR](https://github.com/firebase/firebase-tools-ui/pull/966), the `onSelect` property of the parent `Menu` component is used to replace the `onClick` property of the child `MenuItem` component. This enables screen reader users to click these options using the `space` and `enter` keys.

Internal: Addresses b/263429464