### PR TITLE
Experiment flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,22 @@ GCLOUD_PROJECT=<project-id> FIREBASE_EMULATOR_HUB=localhost:4400 npm start
 
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser. Note: The development server runs by default on port **3000**, so please make sure you are visiting that URL instead of the production Emulator UI (which defaults on port **4000**).
 
+### Developing features behind flags
+
+Experimental CLI features that are activated/deactivated with the `firebase experiments:enable` command are surfaced to the UI via an environment variable. UI components can check if an experiment is active with the `useExperiment` hook:
+
+```jsx
+function ExperimentalFeatureUI() {
+  const showNewFeature = useExperiment("pineapple-smoothie");
+
+  if (showNewFeature === true) {
+    return <h1>Hi, I am an experimental feature</h1>;
+  } else {
+    return null;
+  }
+}
+```
+
 ### Other Available Scripts
 
 In the project directory, you can run:

--- a/server.ts
+++ b/server.ts
@@ -53,12 +53,21 @@ app.get(
   '/api/config',
   jsonHandler(async () => {
     const hubDiscoveryUrl = new URL(`http://${hubHost}/emulators`);
-    const experimentDiscoveryUrl = new URL(`http://${hubHost}/enabled-experiments`);
-    
-    const emulatorConfigRequest = fetch(hubDiscoveryUrl.toString()).then(resp => resp.json());
-    const experimentsRequest = fetch(experimentDiscoveryUrl.toString()).then(resp => resp.json());
+    const experimentDiscoveryUrl = new URL(
+      `http://${hubHost}/enabled-experiments`
+    );
 
-    const [emulators, experiments] = await Promise.all([emulatorConfigRequest, experimentsRequest]);
+    const emulatorConfigRequest = fetch(hubDiscoveryUrl.toString()).then(
+      (resp) => resp.json()
+    );
+    const experimentsRequest = fetch(experimentDiscoveryUrl.toString()).then(
+      (resp) => resp.json()
+    );
+
+    const [emulators, experiments] = await Promise.all([
+      emulatorConfigRequest,
+      experimentsRequest,
+    ]);
     const json = { projectId, ...(emulators as any), ...(experiments as any) };
 
     // Googlers: see go/firebase-emulator-ui-usage-collection-design?pli=1#heading=h.jwz7lj6r67z8

--- a/server.ts
+++ b/server.ts
@@ -53,10 +53,13 @@ app.get(
   '/api/config',
   jsonHandler(async () => {
     const hubDiscoveryUrl = new URL(`http://${hubHost}/emulators`);
-    const emulatorsRes = await fetch(hubDiscoveryUrl.toString());
-    const emulators = (await emulatorsRes.json()) as any;
+    const experimentDiscoveryUrl = new URL(`http://${hubHost}/enabled-experiments`);
+    
+    const emulatorConfigRequest = fetch(hubDiscoveryUrl.toString()).then(resp => resp.json());
+    const experimentsRequest = fetch(experimentDiscoveryUrl.toString()).then(resp => resp.json());
 
-    const json = { projectId, ...emulators };
+    const [emulators, experiments] = await Promise.all([emulatorConfigRequest, experimentsRequest]);
+    const json = { projectId, ...(emulators as any), ...(experiments as any) };
 
     // Googlers: see go/firebase-emulator-ui-usage-collection-design?pli=1#heading=h.jwz7lj6r67z8
     // for more detail

--- a/src/components/common/EmulatorConfigProvider.tsx
+++ b/src/components/common/EmulatorConfigProvider.tsx
@@ -162,7 +162,7 @@ export function useEmulatorConfig<E extends Emulator>(
 }
 
 export function useExperiment(experimentName: string): Boolean {
-  const {experiments} = useConfig();
+  const { experiments } = useConfig();
   return experiments.includes(experimentName);
 }
 

--- a/src/components/common/EmulatorConfigProvider.tsx
+++ b/src/components/common/EmulatorConfigProvider.tsx
@@ -204,7 +204,7 @@ async function configFetcher(url: string): Promise<Config> {
   const result: Config = {
     projectId: json.projectId as string,
     analytics: json.analytics as AnalyticsSession,
-    experiments: json.experiments as Array<string>
+    experiments: json.experiments as Array<string>,
   };
   for (const [key, value] of Object.entries<any>(json)) {
     if (key === 'projectId' || key === 'analytics' || key === 'experiments') {

--- a/src/components/common/EmulatorConfigProvider.tsx
+++ b/src/components/common/EmulatorConfigProvider.tsx
@@ -161,6 +161,11 @@ export function useEmulatorConfig<E extends Emulator>(
   return emulatorConfig as NonNullable<Config[E]>;
 }
 
+export function useExperiment(experimentName: string): Boolean {
+  const {experiments} = useConfig();
+  return experiments.includes(experimentName);
+}
+
 export function useIsEmulatorDisabled(emulator?: Emulator): boolean {
   const config = useConfigOptional();
   if (config === undefined) {

--- a/src/components/common/EmulatorConfigProvider.tsx
+++ b/src/components/common/EmulatorConfigProvider.tsx
@@ -204,9 +204,10 @@ async function configFetcher(url: string): Promise<Config> {
   const result: Config = {
     projectId: json.projectId as string,
     analytics: json.analytics as AnalyticsSession,
+    experiments: json.experiments as Array<string>
   };
   for (const [key, value] of Object.entries<any>(json)) {
-    if (key === 'projectId' || key === 'analytics') {
+    if (key === 'projectId' || key === 'analytics' || key === 'experiments') {
       continue;
     }
     let host = value.host as string;

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -81,4 +81,5 @@ export interface Config {
   hosting?: EmulatorConfig;
   storage?: EmulatorConfig;
   pubsub?: EmulatorConfig;
+  experiments: Array<string>;
 }


### PR DESCRIPTION
Allow experiments set with `firebase experiments:enable` to be accessed by the emulator UI. Corresponding CLI PR: https://github.com/firebase/firebase-tools/pull/6169

The new `useExperiment()` hook will return a list of enabled experiments, so any component that wants to conditionally show UI based on an experiment flag can call this hook:

```jsx
function ExperimentalFeatureUI() {
  const showNewFeature = useExperiment("pineapple-smoothie");

  if (showNewFeature === true) {
    return <h1>Hi, I am an experimental feature</h1>;
  } else {
    return null;
  }
}
```