### PR TITLE
Fix(firestore): Respect data type when applying filter

### DIFF
--- a/src/components/Firestore/CollectionFilter/CollectionFilter.tsx
+++ b/src/components/Firestore/CollectionFilter/CollectionFilter.tsx
@@ -31,11 +31,22 @@ import {
   isSingleValueCollectionFilter,
   isSortableCollectionFilter,
 } from '../models';
+import { isBoolean, isNumber } from '../utils';
 import { useCollectionFilter, useDispatch } from '../store';
 import styles from './CollectionFilter.module.scss';
 import { ConditionEntries } from './ConditionEntries';
 import { ConditionEntry } from './ConditionEntry';
 import { SortRadioGroup } from './SortRadioGroup';
+
+function getConditionEntryType(value: any) {
+  if (isBoolean(value)) {
+    return 'boolean';
+  }
+  if (isNumber(value)) {
+    return 'number';
+  }
+  return 'string';
+}
 
 export const CollectionFilter: React.FC<
   React.PropsWithChildren<{
@@ -54,7 +65,11 @@ export const CollectionFilter: React.FC<
 
   const cf = formMethods.watch();
 
-  const [fieldType, setFieldType] = useState('string');
+  const [fieldType, setFieldType] = useState(
+    getConditionEntryType(
+      isSingleValueCollectionFilter(collectionFilter) && collectionFilter.value
+    )
+  );
 
   const onSubmit = (data: CollectionFilterType) => {
     if (isSingleValueCollectionFilter(data)) {

--- a/src/components/Firestore/CollectionFilter/CollectionFilter.tsx
+++ b/src/components/Firestore/CollectionFilter/CollectionFilter.tsx
@@ -54,7 +54,16 @@ export const CollectionFilter: React.FC<
 
   const cf = formMethods.watch();
 
+  const [fieldType, setFieldType] = useState('string');
+
   const onSubmit = (data: CollectionFilterType) => {
+    if (isSingleValueCollectionFilter(data)) {
+      if (fieldType === 'number') {
+        data.value = Number(data.value);
+      } else if (fieldType === 'boolean') {
+        data.value = data.value === 'true';
+      }
+    }
     dispatch(
       actions.addCollectionFilter({
         path,
@@ -96,7 +105,10 @@ export const CollectionFilter: React.FC<
             preview={<ConditionPreview cf={cf} />}
             defaultOpen
           >
-            <ConditionSelect>
+            <ConditionSelect
+              fieldType={fieldType}
+              setFieldType={setFieldType}
+            >
               {cf && isSingleValueCollectionFilter(cf) && (
                 <ConditionEntry
                   name="value"
@@ -104,6 +116,8 @@ export const CollectionFilter: React.FC<
                     (formMethods.formState.touchedFields as any)['value'] &&
                     (formMethods.formState.errors as any)['value']?.message
                   }
+                  fieldType={fieldType}
+                  setFieldType={setFieldType}
                 />
               )}
 
@@ -207,9 +221,12 @@ const Preview: React.FC<
   );
 };
 
-const ConditionSelect: React.FC<React.PropsWithChildren<unknown>> = ({
-  children,
-}) => {
+const ConditionSelect: React.FC<
+  React.PropsWithChildren<{
+    fieldType: string;
+    setFieldType: (type: string) => void;
+  }>
+> = ({ children, fieldType, setFieldType }) => {
   const options: Array<{
     label: string;
     value: WhereFilterOp;

--- a/src/components/Firestore/CollectionFilter/ConditionEntry.tsx
+++ b/src/components/Firestore/CollectionFilter/ConditionEntry.tsx
@@ -21,29 +21,21 @@ import { Field, SelectField } from '../../../components/common/Field';
 import { NUMBER_REGEX, isBoolean, isNumber } from '../utils';
 import styles from './CollectionFilter.module.scss';
 
-function getConditionEntryType(value: any) {
-  if (isBoolean(value)) {
-    return 'boolean';
-  }
-  if (isNumber(value)) {
-    return 'number';
-  }
-  return 'string';
-}
 
 interface ConditionEntryProps {
   name: string;
   // Error may be undefined; require consumers to still pass or we might end up
   // in a state where we validate without showing the error message.
   error: string | undefined;
+  fieldType: string;
+  setFieldType: (type: string) => void;
 }
 
 export const ConditionEntry: React.FC<
   React.PropsWithChildren<ConditionEntryProps>
-> = React.memo(({ name, error }) => {
+> = React.memo(({ name, error, fieldType, setFieldType }) => {
   const { setValue, watch } = useFormContext();
   const value = watch(name);
-  const [fieldType, setFieldType] = useState(getConditionEntryType(value));
 
   useEffect(() => {
     // Essentially setting the defaultValue of this form-field,
@@ -58,9 +50,7 @@ export const ConditionEntry: React.FC<
       <SelectField
         options={['string', 'number', 'boolean']}
         value={fieldType}
-        onChange={(evt) => {
-          setFieldType(evt.currentTarget.value);
-        }}
+        onChange={(evt) => setFieldType(evt.currentTarget.value)}
         fieldClassName={styles.conditionEntryType}
       />
 


### PR DESCRIPTION
Courtesy of Jules:

The firestore filter view was incorrectly setting the data type to string if the value was entered before the data type was selected. This was because the data type was being inferred from the value itself.

This change lifts the state of the `fieldType` to the parent component, `CollectionFilter.tsx`, and passes it down as a prop. The `onSubmit` function in `CollectionFilter.tsx` now parses the value based on the `fieldType` before dispatching the action. This ensures that the selected data type is always respected, regardless of the order of operations.