### PR TITLE
reverse order of firestore-requests-table 

### DIFF
--- a/src/components/Firestore/Requests/RequestsCard/Table/index.tsx
+++ b/src/components/Firestore/Requests/RequestsCard/Table/index.tsx
@@ -136,7 +136,7 @@ export const RequestsTableWrapper: React.FC<
   const evaluations = useFirestoreRequests(databaseId).requests;
 
   // TODO: Add support for filtering.
-  const filteredEvaluations = evaluations;
+  const filteredEvaluations = evaluations.reverse(); // .reverse() to have newest requests listed first
 
   return (
     <RequestsTable


### PR DESCRIPTION
this is in regards to the following reported [issue(#982)](https://github.com/firebase/firebase-tools-ui/issues/982).

using firebase-tools v14.9.0 with firestore v1.19.8, the locally run emulators-ui were able to reverse the order of requests as intended: 
<img width="1411" height="711" alt="image" src="https://github.com/user-attachments/assets/b8689118-8a9c-417b-bbcb-548bc26b95f2" />
