### PR TITLE
fix(hosting): use dynamic hostname for external link

### DIFF
--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -28,7 +28,7 @@ import { Typography } from '@rmwc/typography';
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-import { Config, EmulatorConfig } from '../../store/config';
+import { Config, EmulatorConfig, hostAndPort } from '../../store/config';
 import { useConfigOptional } from '../common/EmulatorConfigProvider';
 import {
   AuthIcon,
@@ -115,7 +115,10 @@ const Overview: React.FC<
           icon={<HostingIcon theme="secondary" />}
           config={config.hosting}
           testId="emulator-info-hosting"
-          linkToExternal={config.hosting && `//${config.hosting.hostAndPort}/`}
+          linkToExternal={
+            config.hosting &&
+            `//${hostAndPort(window.location.hostname, config.hosting.port)}/`
+          }
           linkLabel="View website"
         />
         <EmulatorCard

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -117,7 +117,7 @@ const Overview: React.FC<
           testId="emulator-info-hosting"
           linkToExternal={
             config.hosting &&
-            `//${hostAndPort(window.location.hostname, config.hosting.port)}/`
+            `//${hostAndPort(window.location.hostname.replace('[', '').replace(']', ''), config.hosting.port)}/`
           }
           linkLabel="View website"
         />


### PR DESCRIPTION
Fixes #1140 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- **Manual:** Verified in a container environment; the Hosting link now dynamically reflects the current hostname, maintaining origin consistency.
- **Automated:** Ran `npm test`, all tests passed successfully.

### The Solution
Instead of relying on the static `config.hosting.hostAndPort` for external navigation, this change dynamically passes `window.location.hostname` into the `hostAndPort` helper directly within the component.

```typescript
// Before
linkToExternal={config.hosting && `//${config.hosting.hostAndPort}/`}

// After
linkToExternal={
  config.hosting &&
  `//${hostAndPort(window.location.hostname, config.hosting.port)}/`
}
